### PR TITLE
fix: add settings to indicate the number of shards and replicas to use for the ES indices

### DIFF
--- a/config/install/ocha_ai.settings.yml
+++ b/config/install/ocha_ai.settings.yml
@@ -33,6 +33,9 @@ plugins:
   vector_store:
     elasticsearch:
       base_index_name: ocha_ai
+      shards: 1
+      replicas: 0
+      nested_object_limit: 100000
 defaults:
   plugins:
     completion:

--- a/config/schema/ocha_ai.schema.yml
+++ b/config/schema/ocha_ai.schema.yml
@@ -272,9 +272,18 @@ ocha_ai.plugin.vector_store.elasticsearch:
     base_index_name:
       type: string
       label: 'The prefix used for the indices.'
+    shards:
+      type: integer
+      label: 'Number of elasticsearch index shards'
+    replicas:
+      type: integer
+      label: 'Number of elasticsearch index replicas'
+    nested_object_limit:
+      type: integer
+      label: 'Maximum number of nested objects'
     indexing_batch_size:
       type: integer
-      label: 'Number of documents to index at conce'
+      label: 'Number of documents to index at once'
     topk:
       type: integer
       label: 'Number of nearest neighbours to retrieve when doing similarity search.'

--- a/src/Plugin/ocha_ai/VectorStore/Elasticsearch.php
+++ b/src/Plugin/ocha_ai/VectorStore/Elasticsearch.php
@@ -122,9 +122,9 @@ class Elasticsearch extends VectorStorePluginBase {
     // publication date so we can generate proper references.
     $payload = [
       'settings' => [
-        'index.mapping.nested_objects.limit' => 100000,
-        'number_of_shards' => 1,
-        'number_of_replicas' => 1,
+        'index.mapping.nested_objects.limit' => $this->getPluginSetting('nested_object_limit', 100000),
+        'number_of_shards' => $this->getPluginSetting('shards', 1),
+        'number_of_replicas' => $this->getPluginSetting('replicas', 0),
       ],
       'mappings' => [
         'properties' => [


### PR DESCRIPTION
Settings override via:

```
$config['ocha_ai.settings']['plugins']['vector_store']['elasticsearch']['shards'] = 1;
$config['ocha_ai.settings']['plugins']['vector_store']['elasticsearch']['replicas'] = 0;
```