### PR TITLE
[RW-893] Style message when feedback is submitted

### DIFF
--- a/modules/ocha_ai_chat/components/chat-form/chat-form.css
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.css
@@ -263,6 +263,24 @@ button doesn't overlay any text */
 }
 
 /**
+ * Feedback message
+ *
+ * Instead of introducing a CD dependency, we add a few status message styles.
+ */
+.ocha-ai-chat-result-feedback .messages {
+  padding: 0.5rem;
+  background: var(--cd-grey--light);
+  border: 1px solid var(--cd-grey--mid);
+  margin-block-start: 0.5rem;
+  border-radius: 3px;
+}
+
+.ocha-ai-chat-result-feedback .messages--status {
+  background-color: var(--cd-green--light);
+  border-color: var(--cd-green);
+}
+
+/**
  * User input area
  */
 /* Textarea */

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -190,6 +190,9 @@ class OchaAiChatChatForm extends FormBase {
         '#title' => $this->t('Please give feedback'),
         '#id' => 'chat-result-' . $index . '-feedback',
         '#open' => FALSE,
+        '#attributes' => [
+          'class' => ['ocha-ai-chat-result-feedback'],
+        ],
       ];
       $form['chat'][$index]['feedback']['satisfaction'] = [
         '#type' => 'select',


### PR DESCRIPTION
# RW-893

⚠️ I unfortunately couldn't debug a major problem before the week ended. PR marked draft. Sorry. ⚠️ 

Now when feedback is submitted, the message that returns looks like a standard Drupal message. The scrolling effect is also disabled for feedback submissions, making it more visible as well.

The show-stopper bug here is that somehow the main submit button will fire N+1 events off after using the feedback mechanism. I tested by submitting feedback more than once, and noted that they always add up to the total number of times you clicked any submit button plus one for the "real" submit button. Here's a screenshot with `console.log` into each function attached to the respective buttons. I took the following actions:

- Press <kbd>Ask</kbd>
- Press <kbd>Submit Feedback</kbd>
- Press <kbd>Ask</kbd>

<img width="1680" alt="Screenshot 2024-03-01 at 16 18 59" src="https://github.com/UN-OCHA/ocha_ai/assets/254753/eeb6509b-3fef-423b-818e-e7b7f5632c4c">

If you submit feedback twice, it'll show the question three times, 3x feedback = 4x question, etc.

I tried inserting `ev.stopPropagation()` in the feedback button, but the bubbling seems to happen inside Drupal code as best I can tell. The <kbd>Ask</kbd> button seemingly gets clicked each time I click the feedback button. It's really hard to screenshot since it's so momentary, but look for the <kbd>Ask</kbd> button to briefly look washed out (like in the screenshot). Additionally, the `chatSend()` isn't getting invoked when <kbd>Submit Feedback</kbd> gets pressed.. they all pile up and fire simultaneously once you finally click <kbd>Ask</kbd> again.