### PR TITLE
[RW-893] Ensure the chat form js is exececuted once

### DIFF
--- a/modules/ocha_ai_chat/components/chat-form/chat-form.js
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.js
@@ -1,3 +1,4 @@
+/* global once */
 (function () {
   'use strict';
 
@@ -15,133 +16,135 @@
 
   Drupal.behaviors.ochaAiChatForm = {
     attach: function (context, settings) {
-      var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
-      var submitButton = document.querySelector('[data-drupal-selector="edit-submit"]');
-      var feedbackButtons = document.querySelectorAll('[data-drupal-selector$="-feedback-submit"]');
-      var chatHeight = this.padChatWindow();
-
-      // Do some calculations to decide where to start our smooth scroll.
-      if (oldScrollHeight && scrollingEnabled) {
-        var smoothScrollStart = oldScrollHeight - chatHeight;
-
-        // Jump to where the bottom of the previous container was before the DOM
-        // got updated. From there, we smooth-scroll to the bottom.
-        chatContainer.scrollTo({top: smoothScrollStart, behavior: 'instant'});
-        chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
-      }
-      else if (scrollingEnabled) {
-        chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
-      }
-      else {
-        chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'instant'});
-
-        // Now that we completed the non-scroll action, set the variable back to
-        // TRUE for the next user interaction.
-        scrollingEnabled = true;
-      }
-
-      /**
-       * Chat submission.
-       *
-       * Upate UI when submit is pressed. Each time ajax finishes, the whole
-       * chat history will be re-inserted into the DOM. That means we can
-       * temporarily inject whatever we like and it will get cleaned up for us.
-       */
-      function chatSend (ev) {
-        // First check the question textarea for a value. We don't want to act
-        // unless we have a value to send.
-        var questionValue = document.querySelector('[data-drupal-selector="edit-question"]').value;
-
-        // If we couldn't find a question, exit early.
-        if (!questionValue) {
-          ev.preventDefault();
-          return;
-        }
-
-        // Build DOM nodes to be inserted.
+      once('ocha-ai-chat-form', '[data-drupal-selector="edit-chat"]', context).forEach(element => {
         var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
-        var chatResult = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
-          'class': 'ocha-ai-chat-result',
-        }, {});
-        var questionDl = Drupal.behaviors.ochaAiChatUtils.createElement('dl', {
-          'class': 'chat',
-        }, {});
-        var questionWrapper = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
-          'class': 'chat__q chat__q--loading',
-        }, {});
-        var questionDt = Drupal.behaviors.ochaAiChatUtils.createElement('dt', {
-          'class': 'visually-hidden',
-        }, 'Question');
-        var questionDd = Drupal.behaviors.ochaAiChatUtils.createElement('dd', {}, questionValue);
+        var submitButton = document.querySelector('[data-drupal-selector="edit-submit"]');
+        var feedbackButtons = document.querySelectorAll('[data-drupal-selector$="-feedback-submit"]');
+        var chatHeight = this.padChatWindow();
 
-        // Prep all the DOM nodes for insertion.
-        questionWrapper.append(questionDt);
-        questionWrapper.append(questionDd);
-        questionDl.append(questionWrapper);
-        chatResult.append(questionDl);
+        // Do some calculations to decide where to start our smooth scroll.
+        if (oldScrollHeight && scrollingEnabled) {
+          var smoothScrollStart = oldScrollHeight - chatHeight;
 
-        // Introduce a small delay before question gets inserted into DOM.
-        setTimeout(() => {
-          chatContainer.append(chatResult);
-
-          // In this instance we use smooth scrolling. It won't be smooth unless
-          // the continer can be scrolled to begin with, but if padding was able
-          // to be added when the window opened, then it should work from the
-          // very beginning of the chat history.
+          // Jump to where the bottom of the previous container was before the DOM
+          // got updated. From there, we smooth-scroll to the bottom.
+          chatContainer.scrollTo({top: smoothScrollStart, behavior: 'instant'});
           chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
-
-          // Store the scroll position so that we can attempt to smooth-scroll
-          // when the form reloads with new data attached.
-          oldScrollHeight = chatContainer.scrollHeight;
-        }, 200);
-      };
-
-      // Check all the input modes and add our client-side chat effects to the
-      // form's main submit button.
-      //
-      // We use `mousedown` instead of `click` because the latter didn't seem to
-      // have any effect when testing. It's possible that Drupal stops event
-      // propagation, preventing a `click` from ever executing.
-      //
-      // Note: Drupal 10 has a bug that might seem like we introduced, but
-      // its behavior comes from core. Ajax event listeners use mousedown so
-      // forms will submit even when doing actions like right-click which aren't
-      // meant to submit the form.
-      //
-      // @see https://www.drupal.org/project/drupal/issues/2616184
-      submitButton.addEventListener('touchend', chatSend);
-      submitButton.addEventListener('mousedown', chatSend);
-      submitButton.addEventListener('keydown', function(ev) {
-        // First check that the [Enter] key is being pressed.
-        if (ev.keyCode === 13) {
-          chatSend(ev);
         }
-      });
+        else if (scrollingEnabled) {
+          chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
+        }
+        else {
+          chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'instant'});
 
-      /**
-       * Feedback submission
-       */
-      function feedbackSend(ev) {
-        // Disable scrolling on next ajax reload. The `attach` function contains
-        // logic which will reset this to true.
-        scrollingEnabled = false;
-      }
+          // Now that we completed the non-scroll action, set the variable back to
+          // TRUE for the next user interaction.
+          scrollingEnabled = true;
+        }
 
-      // Listen for feedback button and disable scrolling.
-      feedbackButtons.forEach((el) => {
-        el.addEventListener('touchend', feedbackSend);
-        el.addEventListener('mousedown', feedbackSend);
-        el.addEventListener('keydown', function(ev) {
+        /**
+         * Chat submission.
+         *
+         * Upate UI when submit is pressed. Each time ajax finishes, the whole
+         * chat history will be re-inserted into the DOM. That means we can
+         * temporarily inject whatever we like and it will get cleaned up for us.
+         */
+        function chatSend (ev) {
+          // First check the question textarea for a value. We don't want to act
+          // unless we have a value to send.
+          var questionValue = document.querySelector('[data-drupal-selector="edit-question"]').value;
+
+          // If we couldn't find a question, exit early.
+          if (!questionValue) {
+            ev.preventDefault();
+            return;
+          }
+
+          // Build DOM nodes to be inserted.
+          var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
+          var chatResult = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
+            'class': 'ocha-ai-chat-result',
+          }, {});
+          var questionDl = Drupal.behaviors.ochaAiChatUtils.createElement('dl', {
+            'class': 'chat',
+          }, {});
+          var questionWrapper = Drupal.behaviors.ochaAiChatUtils.createElement('div', {
+            'class': 'chat__q chat__q--loading',
+          }, {});
+          var questionDt = Drupal.behaviors.ochaAiChatUtils.createElement('dt', {
+            'class': 'visually-hidden',
+          }, 'Question');
+          var questionDd = Drupal.behaviors.ochaAiChatUtils.createElement('dd', {}, questionValue);
+
+          // Prep all the DOM nodes for insertion.
+          questionWrapper.append(questionDt);
+          questionWrapper.append(questionDd);
+          questionDl.append(questionWrapper);
+          chatResult.append(questionDl);
+
+          // Introduce a small delay before question gets inserted into DOM.
+          setTimeout(() => {
+            chatContainer.append(chatResult);
+
+            // In this instance we use smooth scrolling. It won't be smooth unless
+            // the continer can be scrolled to begin with, but if padding was able
+            // to be added when the window opened, then it should work from the
+            // very beginning of the chat history.
+            chatContainer.scrollTo({top: chatContainer.scrollHeight, behavior: 'smooth'});
+
+            // Store the scroll position so that we can attempt to smooth-scroll
+            // when the form reloads with new data attached.
+            oldScrollHeight = chatContainer.scrollHeight;
+          }, 200);
+        };
+
+        // Check all the input modes and add our client-side chat effects to the
+        // form's main submit button.
+        //
+        // We use `mousedown` instead of `click` because the latter didn't seem to
+        // have any effect when testing. It's possible that Drupal stops event
+        // propagation, preventing a `click` from ever executing.
+        //
+        // Note: Drupal 10 has a bug that might seem like we introduced, but
+        // its behavior comes from core. Ajax event listeners use mousedown so
+        // forms will submit even when doing actions like right-click which aren't
+        // meant to submit the form.
+        //
+        // @see https://www.drupal.org/project/drupal/issues/2616184
+        submitButton.addEventListener('touchend', chatSend);
+        submitButton.addEventListener('mousedown', chatSend);
+        submitButton.addEventListener('keydown', function(ev) {
           // First check that the [Enter] key is being pressed.
           if (ev.keyCode === 13) {
-            feedbackSend(ev);
+            chatSend(ev);
           }
         });
-      });
 
-      // Listen for window resizes and recalculate the amount of padding needed
-      // within the chat history.
-      window.addEventListener('resize', Drupal.debounce(this.padChatWindow, 33));
+        /**
+         * Feedback submission
+         */
+        function feedbackSend(ev) {
+          // Disable scrolling on next ajax reload. The `attach` function contains
+          // logic which will reset this to true.
+          scrollingEnabled = false;
+        }
+
+        // Listen for feedback button and disable scrolling.
+        feedbackButtons.forEach((el) => {
+          el.addEventListener('touchend', feedbackSend);
+          el.addEventListener('mousedown', feedbackSend);
+          el.addEventListener('keydown', function(ev) {
+            // First check that the [Enter] key is being pressed.
+            if (ev.keyCode === 13) {
+              feedbackSend(ev);
+            }
+          });
+        });
+
+        // Listen for window resizes and recalculate the amount of padding needed
+        // within the chat history.
+        window.addEventListener('resize', Drupal.debounce(this.padChatWindow, 33));
+      });
     },
 
     // Calculates the size of the chat window and adds padding to ensure there

--- a/modules/ocha_ai_job_tag/src/Services/OchaAiJobTagTagger.php
+++ b/modules/ocha_ai_job_tag/src/Services/OchaAiJobTagTagger.php
@@ -8,7 +8,6 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\Core\State\StateInterface;
-use Drupal\ocha_ai_chat\Services\OchaAiChat;
 use Drupal\ocha_ai\Helpers\VectorHelper;
 use Drupal\ocha_ai\Plugin\CompletionPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\EmbeddingPluginManagerInterface;
@@ -16,6 +15,7 @@ use Drupal\ocha_ai\Plugin\SourcePluginManagerInterface;
 use Drupal\ocha_ai\Plugin\TextExtractorPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\TextSplitterPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\VectorStorePluginManagerInterface;
+use Drupal\ocha_ai_chat\Services\OchaAiChat;
 
 /**
  * OCHA AI Chat service.


### PR DESCRIPTION
Refs: RW-893

This is to against the [RW-893](https://github.com/UN-OCHA/ocha_ai/tree/RW-893) branch.

Use `?w=1` to more easily see the 3 line changes: https://github.com/UN-OCHA/ocha_ai/pull/9/files?w=1

This wraps the code of the ochaAiChatForm drupal behavior in a `once` to ensure it's executed only once otherwise, the event handlers are added twice. First when the form is loaded and a second time after pressing "ask", which causes new questions to appear twice when pressing "ask" after the first question.

Note: as a rule of thumb, it's safer to wrap the content of a Drupal behavior `attach` method in a [once](https://www.drupal.org/node/3158256) or something [equivalent](https://github.com/UN-OCHA/ocha_ai/blob/f6c9101255c3e95c52eab4da312877c5f374c8c9/modules/ocha_ai_chat/components/chat-popup/chat-popup.js#L5-L6) like adding a `bla-bla-processed` attribute. Drupal executes again the attached behaviors after an ajax call and without the once/attribute the code would be run again.


[RW-893]: https://humanitarian.atlassian.net/browse/RW-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ