### PR TITLE
[RW-928] both feedback modes + new column

### DIFF
--- a/modules/ocha_ai_chat/components/chat-form/chat-form.css
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.css
@@ -135,7 +135,7 @@ button doesn't overlay any text */
  */
 .ocha-ai-chat-chat-form details {
   display: block;
-  margin: 0 12px;
+  margin: 0;
   padding: 12px;
   border: 1px solid #ddd;
   border-radius: 3px;
@@ -166,6 +166,10 @@ button doesn't overlay any text */
 
 .ocha-ai-chat-chat-form input[type="text"] {
   max-width: 100%;
+}
+
+.ocha-ai-chat-chat-form__advanced {
+  margin-inline: 12px;
 }
 
 /**

--- a/modules/ocha_ai_chat/components/chat-form/chat-form.css
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.css
@@ -341,12 +341,18 @@ button.feedback-button.feedback-button.feedback-button.feedback-button:focus {
   background-color: var(--cd-green--light);
 }
 
-/* for copy button only */
-.ocha-ai-chat-result-feedback .feedback-button--copy + [role="status"] {
-  font-size: .8em;
-  margin-inline-start: 0.5rem;
+/**
+ * Clipboard feedback message
+ */
+.clipboard-feedback {
+  font-size: .75em;
   position: relative;
   top: -3px;
+  background: var(--cd-black);
+  color: var(--cd-white);
+  border-radius: 3px;
+  margin-inline-start: 0.5rem;
+  padding: 0.2rem 0.25rem;
 }
 
 /**

--- a/modules/ocha_ai_chat/ocha_ai_chat.install
+++ b/modules/ocha_ai_chat/ocha_ai_chat.install
@@ -133,6 +133,13 @@ function ocha_ai_chat_schema() {
         'size' => 'medium',
         'not null' => FALSE,
       ],
+      'thumbs' => [
+        'description' => 'Whether user clicked thumbs up or down.',
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => TRUE,
+        'default' => '',
+      ],
     ],
     'primary key' => ['id'],
   ];
@@ -196,4 +203,23 @@ function ocha_ai_chat_update_10003(array &$sandbox) {
   if (!$schema->tableExists('ocha_ai_chat_preferences')) {
     $schema->createTable('ocha_ai_chat_preferences', ocha_ai_chat_schema()['ocha_ai_chat_preferences']);
   }
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Add field to the OCHA AI chat logs table.
+ */
+function ocha_ai_chat_update_10004(array &$sandbox) {
+  $schema = \Drupal::database()->schema();
+
+  $thumbs = [
+    'description' => 'Whether user clicked thumbs up or down.',
+    'type' => 'text',
+    'size' => 'normal',
+    'not null' => TRUE,
+    'default' => '',
+  ];
+
+  $schema->addField('ocha_ai_chat_logs', 'thumbs', $thumbs);
 }

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -242,7 +242,7 @@ class OchaAiChatChatForm extends FormBase {
         // Copy button.
         $form['chat'][$index]['feedback_simple']['copy'] = [
           '#type' => 'inline_template',
-          '#template' => '<span><button class="feedback-button feedback-button--copy" data-for="{{ answer_id }}" data-message="{{ success_message }}"><span class="visually-hidden">Copy to clipboard</span></button><span hidden role="status" class="messages messages--status"></span></span>',
+          '#template' => '<span><button class="feedback-button feedback-button--copy" data-for="{{ answer_id }}" data-message="{{ success_message }}"><span class="visually-hidden">Copy to clipboard</span></button><span hidden role="status" class="clipboard-feedback"></span></span>',
           '#context' => [
             'answer_id' => $answer_id,
             'success_message' => $this->t('Answer was copied to clipboard'),

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -452,16 +452,18 @@ class OchaAiChatChatForm extends FormBase {
     // Convert the thumbs up/down to an integer.
     if ($feedback === 'good') {
       $feedback_val = 'up';
+      $feedback_msg = $this->t('Glad you liked this answer.');
     }
     else {
       $feedback_val = 'down';
+      $feedback_msg = $this->t('Thank you for your feedback.');
     }
 
     // Record the feedback.
     $this->ochaAiChat->addAnswerThumbs($id, $feedback_val);
 
     $response = new AjaxResponse();
-    $response->addCommand(new MessageCommand($this->t('Feedback submitted, thank you.'), $selector));
+    $response->addCommand(new MessageCommand($feedback_msg, $selector));
     return $response;
   }
 

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -211,7 +211,7 @@ class OchaAiChatChatForm extends FormBase {
         $form['chat'][$index]['feedback_simple']['good'] = [
           '#type' => 'submit',
           '#name' => 'chat-result-' . $index . '-simple-feedback-good',
-          '#value' => $this->t('Good'),
+          '#value' => $this->t('Like'),
           '#attributes' => [
             'class' => ['feedback-button', 'feedback-button--good'],
             'data-result-id' => $record['id'],
@@ -227,7 +227,7 @@ class OchaAiChatChatForm extends FormBase {
         $form['chat'][$index]['feedback_simple']['bad'] = [
           '#type' => 'submit',
           '#name' => 'chat-result-' . $index . '-simple-feedback-bad',
-          '#value' => $this->t('Bad'),
+          '#value' => $this->t('Dislike'),
           '#attributes' => [
             'class' => ['feedback-button', 'feedback-button--bad'],
             'data-result-id' => $record['id'],

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -193,9 +193,11 @@ class OchaAiChatChatForm extends FormBase {
         ],
       ];
 
-      if ($feedback_type === 'simple') {
+      // There are multiple "modes" for feedback. We check the config value/
+      // before deciding what UI widgets to render.
+      if ($feedback_type === 'simple' || $feedback_type === 'both') {
         // Container for simple feedback.
-        $form['chat'][$index]['feedback'] = [
+        $form['chat'][$index]['feedback_simple'] = [
           '#type' => 'fieldset',
           '#title' => $this->t('Provide feedback'),
           '#title_display' => 'invisible',
@@ -206,7 +208,7 @@ class OchaAiChatChatForm extends FormBase {
         ];
 
         // Thumbs up.
-        $form['chat'][$index]['feedback']['good'] = [
+        $form['chat'][$index]['feedback_simple']['good'] = [
           '#type' => 'submit',
           '#name' => 'chat-result-' . $index . '-simple-feedback-good',
           '#value' => $this->t('Good'),
@@ -222,7 +224,7 @@ class OchaAiChatChatForm extends FormBase {
         ];
 
         // Thumbs down.
-        $form['chat'][$index]['feedback']['bad'] = [
+        $form['chat'][$index]['feedback_simple']['bad'] = [
           '#type' => 'submit',
           '#name' => 'chat-result-' . $index . '-simple-feedback-bad',
           '#value' => $this->t('Bad'),
@@ -238,7 +240,7 @@ class OchaAiChatChatForm extends FormBase {
         ];
 
         // Copy button.
-        $form['chat'][$index]['feedback']['copy'] = [
+        $form['chat'][$index]['feedback_simple']['copy'] = [
           '#type' => 'inline_template',
           '#template' => '<span><button class="feedback-button feedback-button--copy" data-for="{{ answer_id }}" data-message="{{ success_message }}"><span class="visually-hidden">Copy to clipboard</span></button><span hidden role="status" class="messages messages--status"></span></span>',
           '#context' => [
@@ -247,7 +249,9 @@ class OchaAiChatChatForm extends FormBase {
           ],
         ];
       }
-      else {
+
+      // Detailed feedback.
+      if ($feedback_type !== 'simple') {
         $form['chat'][$index]['feedback'] = [
           '#type' => 'details',
           '#title' => $this->t('Please give feedback'),
@@ -447,16 +451,14 @@ class OchaAiChatChatForm extends FormBase {
 
     // Convert the thumbs up/down to an integer.
     if ($feedback === 'good') {
-      $feedback_int = 4;
-      $feedback_msg = 'User clicked thumbs up';
+      $feedback_val = 'up';
     }
     else {
-      $feedback_int = 2;
-      $feedback_msg = 'User clicked thumbs down';
+      $feedback_val = 'down';
     }
 
     // Record the feedback.
-    $this->ochaAiChat->addAnswerFeedback($id, $feedback_int, $feedback_msg);
+    $this->ochaAiChat->addAnswerThumbs($id, $feedback_val);
 
     $response = new AjaxResponse();
     $response->addCommand(new MessageCommand($this->t('Feedback submitted, thank you.'), $selector));

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -254,7 +254,7 @@ class OchaAiChatChatForm extends FormBase {
       if ($feedback_type !== 'simple') {
         $form['chat'][$index]['feedback'] = [
           '#type' => 'details',
-          '#title' => $this->t('Please give feedback'),
+          '#title' => $this->t('Provide detailed feedback'),
           '#id' => 'chat-result-' . $index . '-feedback',
           '#open' => FALSE,
           '#attributes' => [

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
@@ -154,6 +154,7 @@ class OchaAiChatConfigForm extends FormBase {
       '#options' => [
         'detailed' => $this->t('Detailed feedback'),
         'simple' => $this->t('Simple feedback'),
+        'both' => $this->t('Both feedback modes'),
       ],
       '#description' => $this->t('Simple feedback displays a thumbs up/down instead of offering open comment fields on each answer.'),
     ];

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatLogsForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatLogsForm.php
@@ -197,6 +197,9 @@ class OchaAiChatLogsForm extends FormBase {
       'feedback' => [
         'data' => $this->t('Feedback'),
       ],
+      'thumbs' => [
+        'data' => $this->t('Thumbs'),
+      ],
       'stats' => [
         'data' => $this->t('Stats'),
       ],
@@ -265,6 +268,7 @@ class OchaAiChatLogsForm extends FormBase {
             ],
           ],
         ],
+        'thumbs' => $record->thumbs ?? '',
         'stats' => [
           'data' => [
             '#type' => 'details',

--- a/modules/ocha_ai_chat/src/Services/OchaAiChat.php
+++ b/modules/ocha_ai_chat/src/Services/OchaAiChat.php
@@ -375,6 +375,29 @@ class OchaAiChat {
   }
 
   /**
+   * Add thumbs up/down to an answer's log entry.
+   *
+   * @param int $id
+   *   The ID of the answer log.
+   * @param string $value
+   *   Up or down.
+   *
+   * @return bool
+   *   TRUE if a record was updated.
+   */
+  public function addAnswerThumbs(int $id, string $value): bool {
+    $updated = $this->database
+      ->update('ocha_ai_chat_logs')
+      ->fields([
+        'thumbs' => $value,
+      ])
+      ->condition('id', $id, '=')
+      ->execute();
+
+    return !empty($updated);
+  }
+
+  /**
    * Get a list of source documents for the given document source URL.
    *
    * @param array $source


### PR DESCRIPTION
Refs: RW-928

- New config option for feedback mode: `both`
- Tweaks to form to allow both feedback modes to co-exist.
- New column on logs table exclusively for thumbs up/down.
- New function inside thumbs up/down callback to store data.

I had some weird trouble with the config form so even though I added very little to the config form, please make sure I didn't screw it up.