### PR TITLE
feat(ux): better formatting for Chat answers

### DIFF
--- a/modules/ocha_ai_chat/components/chat-form/chat-form.js
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.js
@@ -247,7 +247,7 @@
         // Add our event listener so people can copy to clipboard.
         el.addEventListener('click', function (ev) {
           var tempInput = document.createElement('input');
-          var textToCopy = document.querySelector('#' + el.dataset.for).textContent;
+          var textToCopy = document.querySelector('#' + el.dataset.for).innerHTML.replaceAll('<br>', '\n');
 
           try {
             if (navigator.clipboard) {

--- a/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
+++ b/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
@@ -4,6 +4,7 @@ defaults:
       value: ''
       format: 'plain_text'
     feedback: ''
+    formatting: 'basic'
   plugins:
     completion:
       plugin_id: aws_bedrock

--- a/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
+++ b/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
@@ -63,6 +63,9 @@ ocha_ai_chat.settings:
             feedback:
               type: string
               label: 'Feedback mode.'
+            formatting:
+              type: string
+              label: 'Formatting mode.'
         plugins:
           type: mapping
           label: 'Default plugins.'

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -171,6 +171,7 @@ class OchaAiChatChatForm extends FormBase {
 
     // Get the feedback type to use for each history entry.
     $feedback_type = $defaults['form']['feedback'] ?? 'detailed';
+    $formatting = $defaults['form']['formatting'] ?? 'none';
 
     foreach (json_decode($history, TRUE) ?? [] as $index => $record) {
       // Used on two different form elements; they must match to function.
@@ -184,10 +185,10 @@ class OchaAiChatChatForm extends FormBase {
       ];
       $form['chat'][$index]['result'] = [
         '#type' => 'inline_template',
-        '#template' => '<dl class="chat"><div class="chat__q"><dt class="visually-hidden">Question</dt><dd>{{ question }}</dd></div><div class="chat__a"><dt class="visually-hidden">Answer</dt><dd id="{{ answer_id }}">{{ answer }}</dd></div>{% if references %}<div class="chat__refs"><dt>References</dt><dd>{{ references }}</dd></div>{% endif %}</dl>',
+        '#template' => '<dl class="chat"><div class="chat__q"><dt class="visually-hidden">Question</dt><dd>{{ question }}</dd></div><div class="chat__a"><dt class="visually-hidden">Answer</dt><dd id="{{ answer_id }}">{{ answer|raw }}</dd></div>{% if references %}<div class="chat__refs"><dt>References</dt><dd>{{ references }}</dd></div>{% endif %}</dl>',
         '#context' => [
           'question' => $record['question'],
-          'answer' => $record['answer'],
+          'answer' => $formatting !== 'none' ? $this->formatAnswer($record['answer'], $formatting) : $record['answer'],
           'answer_id' => $answer_id,
           'references' => $this->formatReferences($record['references']),
         ],
@@ -504,6 +505,33 @@ class OchaAiChatChatForm extends FormBase {
       ->execute();
 
     return $form['instructions'];
+  }
+
+  /**
+   * Format an answer.
+   *
+   * @param string $answer
+   *   Answer.
+   * @param string $format
+   *   Formatting mode.
+   *
+   * @return string
+   *   String of HTML.
+   */
+  protected function formatAnswer(string $answer, string $format): string {
+    if (!$answer) {
+      return '';
+    }
+
+    // If none of the following formatting applies, return the original answer.
+    $formatted_answer = $answer;
+
+    // Restore line breaks. The LLM returns line breaks, but they need to be
+    // converted to HTML to be seen in the browser.
+    $formatted_answer = str_replace("\n", '<br>', $formatted_answer);
+
+    // Return formatted answer.
+    return $formatted_answer;
   }
 
   /**

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
@@ -163,8 +163,8 @@ class OchaAiChatConfigForm extends FormBase {
       '#title' => $this->t('Formatting'),
       '#default_value' => $defaults['form']['formatting'] ?? '',
       '#options' => [
-        'none' => $this->t('No special formatting.'),
-        'basic' => $this->t('Basic formatting.'),
+        'none' => $this->t('No special formatting'),
+        'basic' => $this->t('Basic formatting'),
       ],
       '#description' => $this->t('Basic formatting means that the module takes the answer from the LLM and restores line breaks within HTML.'),
     ];

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
@@ -158,6 +158,16 @@ class OchaAiChatConfigForm extends FormBase {
       ],
       '#description' => $this->t('Simple feedback displays a thumbs up/down instead of offering open comment fields on each answer.'),
     ];
+    $form['defaults']['form']['formatting'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Formatting'),
+      '#default_value' => $defaults['form']['formatting'] ?? '',
+      '#options' => [
+        'none' => $this->t('No special formatting.'),
+        'basic' => $this->t('Basic formatting.'),
+      ],
+      '#description' => $this->t('Basic formatting means that the module takes the answer from the LLM and restores line breaks within HTML.'),
+    ];
 
     $form['defaults']['plugins'] = [
       '#type' => 'details',


### PR DESCRIPTION
Refs: RW-930

- New `ocha_ai_chat.settings` option: `form.formatting` with default value `basic`
- I put another formatting function into the chat form class. Right now it does the same job as twig filter `nl2br` but I still chose to do it in a function in case we want to add additional processing, or perhaps more granular formatting options in the future.

## Testing

- Check out branch
- Navigate to OCHA AI Chat config in the Drupal admin, choose "Basic formatting" in the top section.
- Navigate to an Update and ask a question whose answer will require formatting, such as "Give me three talking points"
- The line breaks should be visible in the answer like the screenshot below.
- Copying the answer to clipboard should retain the line breaks.

<img width="461" alt="Screenshot 2024-04-05 at 13 51 16" src="https://github.com/UN-OCHA/ocha_ai/assets/254753/8e249786-0369-44f7-a5ce-04ee1c036ebb">
