### PR TITLE
[RW-937] Log use of the Copy to Clipboard button

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ This implements a RAG (retrieval augmented generation) approach:
 
 The "chat" functionality is provided by the [OchaAiChat](modules/ocha_ai_chat/src/Services/OchaAiChat.php) service. This service glues the different plugins together.
 
+### User feedback on answers (Chat)
+
+There are three feedback modes that visitors might see:
+
+- **Default:** is an expandable area presenting a dropdown with values 1-5, plus an open textarea for comments.
+- **Simple mode:** presents a thumbs up/down. Set config `ocha_ai_chat.settings.feedback='simple'` to adopt this UI, which replaces the default feedback UI. The data is stored in a separate `thumbs` column in the logs table.
+- **Combined mode:** presents both widgets alongside each other.
+
+Additionally, the Copy to Clipboard button can now store whether it was clicked for each answer. This data is found in the `copied` column of the logs table.
+
 ### TODO (Chat)
 
 #### Plugins for Chat
@@ -100,13 +110,6 @@ The "chat" functionality is provided by the [OchaAiChat](modules/ocha_ai_chat/sr
 
 - [ ] Log requests (debug mode --> add setting to plugins).
 - [ ] Log number of pages, passages and estimated count of tokens.
-
-#### Feedback on answers
-
-There are two feedback modes that visitors might see:
-
-- **Default:** is an expandable area presenting a dropdown with values 1-5, plus an open textarea for comments.
-- **Simple mode:** presents a thumbs up/down. Set config `ocha_ai_chat.settings.feedback='simple'` to adopt this UI, which uses the same DB schema as the other. Thumbs-up is converted to a 4, thumbs-down a 2. The comment field will note that the relevant button was clicked.
 
 ## OCHA AI Tag Module
 

--- a/modules/ocha_ai_chat/components/chat-form/chat-form.js
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.js
@@ -241,11 +241,13 @@
 
       // Process links so they copy URL to clipboard.
       copyButtons.forEach(function (el) {
-        // First, define the status element for each button.
-        var status = el.parentNode.querySelector('[role=status]');
 
         // Add our event listener so people can copy to clipboard.
-        el.addEventListener('click', function (ev) {
+        //
+        // As of hook_update_10005() the button is hooked up to the Drupal form
+        // so that it can submit and record that the copy button was pressed.
+        // Drupal handles displaying feedback to the user.
+        el.addEventListener('mousedown', function (ev) {
           var tempInput = document.createElement('input');
           var textToCopy = document.querySelector('#' + el.dataset.for).innerHTML.replaceAll('<br>', '\n');
 
@@ -262,23 +264,6 @@
               document.execCommand('copy');
               document.body.removeChild(tempInput);
             }
-
-            // If we got this far, don't let the link click through.
-            ev.preventDefault();
-            ev.stopPropagation();
-
-            // Show user feedback and remove after some time.
-            status.removeAttribute('hidden');
-            status.innerText = el.dataset.message;
-
-            // Hide message.
-            setTimeout(function () {
-              status.setAttribute('hidden', '');
-            }, 2500);
-            // After message is hidden, remove status contents.
-            setTimeout(function () {
-              status.innerText = '';
-            }, 3000);
           }
           catch (err) {
             // Log errors to console.

--- a/modules/ocha_ai_chat/ocha_ai_chat.install
+++ b/modules/ocha_ai_chat/ocha_ai_chat.install
@@ -140,6 +140,13 @@ function ocha_ai_chat_schema() {
         'not null' => TRUE,
         'default' => '',
       ],
+      'copied' => [
+        'description' => 'Whether user copied an answer to clipboard.',
+        'type' => 'text',
+        'size' => 'normal',
+        'not null' => TRUE,
+        'default' => '',
+      ],
     ],
     'primary key' => ['id'],
   ];
@@ -208,7 +215,7 @@ function ocha_ai_chat_update_10003(array &$sandbox) {
 /**
  * Implements hook_update_N().
  *
- * Add field to the OCHA AI chat logs table.
+ * Add 'thumbs' field to the OCHA AI chat logs table.
  */
 function ocha_ai_chat_update_10004(array &$sandbox) {
   $schema = \Drupal::database()->schema();
@@ -222,4 +229,23 @@ function ocha_ai_chat_update_10004(array &$sandbox) {
   ];
 
   $schema->addField('ocha_ai_chat_logs', 'thumbs', $thumbs);
+}
+
+/**
+ * Implements hook_update_N().
+ *
+ * Add 'copied' field to the OCHA AI chat logs table.
+ */
+function ocha_ai_chat_update_10005(array &$sandbox) {
+  $schema = \Drupal::database()->schema();
+
+  $copied = [
+    'description' => 'Whether user copied an answer to clipboard.',
+    'type' => 'text',
+    'size' => 'normal',
+    'not null' => TRUE,
+    'default' => '',
+  ];
+
+  $schema->addField('ocha_ai_chat_logs', 'copied', $copied);
 }

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatLogsForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatLogsForm.php
@@ -200,6 +200,9 @@ class OchaAiChatLogsForm extends FormBase {
       'thumbs' => [
         'data' => $this->t('Thumbs'),
       ],
+      'copied' => [
+        'data' => $this->t('Copied'),
+      ],
       'stats' => [
         'data' => $this->t('Stats'),
       ],
@@ -269,6 +272,7 @@ class OchaAiChatLogsForm extends FormBase {
           ],
         ],
         'thumbs' => $record->thumbs ?? '',
+        'copied' => $record->copied ?? '',
         'stats' => [
           'data' => [
             '#type' => 'details',

--- a/modules/ocha_ai_chat/src/Services/OchaAiChat.php
+++ b/modules/ocha_ai_chat/src/Services/OchaAiChat.php
@@ -398,6 +398,29 @@ class OchaAiChat {
   }
 
   /**
+   * Record that a copy-to-clipboard button was used.
+   *
+   * @param int $id
+   *   The ID of the answer log.
+   * @param string $value
+   *   Copied or not.
+   *
+   * @return bool
+   *   TRUE if a record was updated.
+   */
+  public function addAnswerCopy(int $id, string $value): bool {
+    $updated = $this->database
+      ->update('ocha_ai_chat_logs')
+      ->fields([
+        'copied' => $value,
+      ])
+      ->condition('id', $id, '=')
+      ->execute();
+
+    return !empty($updated);
+  }
+
+  /**
    * Get a list of source documents for the given document source URL.
    *
    * @param array $source


### PR DESCRIPTION
# RW-937

- Added new `copied` column to OCHA AI Chat logs table
- Convert Clipboard button to a Drupal submit button, removed client-side feedback elements
- Refactor JS to remove feedback display logic
- Added new method to record clipboard clicks
- Hooked form up to new method which displays feedback after successful update on backend.

## Testing

- Check out branch and run `drush updb` to add new column to table
- Navigate to an Update and ask something in the Chat
- Click the Copy button and see that the standard Drupal Message shows up below the feedback widget (it used to appear to the side) like shown below
- The logs table should now show a value in the `Copied` column: the word `copied` should appear in the relevant row of the table.

<img width="475" alt="Screenshot 2024-04-18 at 15 08 22" src="https://github.com/UN-OCHA/ocha_ai/assets/254753/997daee8-6ffb-4673-bad7-347e47e33ff2">
