### PR TITLE
[RW-1006] Submit question when pressing enter in the question textarea

### DIFF
--- a/modules/ocha_ai_chat/components/chat-form/chat-form.js
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.js
@@ -15,6 +15,7 @@
       once('ocha-ai-chat-form', '[data-drupal-selector="edit-chat"]', context).forEach(element => {
         var chatContainer = document.querySelector('[data-drupal-selector="edit-chat"] .fieldset-wrapper');
         var submitButton = document.querySelector('[data-drupal-selector="edit-submit"]');
+        var questionTextarea = document.querySelector('[data-drupal-selector="edit-question"]');
         var chatHeight = this.padChatWindow();
 
         // Do some calculations to decide where to start our smooth scroll.
@@ -108,6 +109,17 @@
           // First check that the [Enter] key is being pressed.
           if (ev.keyCode === 13) {
             chatSend(ev);
+          }
+        });
+
+        // Initialize the event so that pressing enter in the input textarea
+        // submits the form.
+        questionTextarea.addEventListener('keydown', function (event) {
+          if (event.keyCode == 13 && !event.shiftKey) {
+            event.preventDefault();
+            // We don't call chatSend directly because this will not trigger
+            // the ajax event attached to the submit button.
+            submitButton.dispatchEvent(new Event('mousedown'));
           }
         });
 


### PR DESCRIPTION
Refs: RW-1006

Submit the question when pressing enter in the question textarea.

## Tests

1. Make sure to have the `ocha_ai` use this PR's branch (add `- "../../ocha_ai:/srv/www/html/modules/contrib/ocha_ai:ro"` for example in the local/docker.compose.yml).
2. Clear the cache
3. Open a report on your local RW (do a hard refresh to make sure the `ocha_form.js` is the newest version)
4. Open the chat popup, type a question
5. Still in the textare, press `shift` + `enter` to confirm, you can add a new line
6. Press `enter` and confirm that is submits the question