### PR TITLE
[RW-1020] Allow setting the popup and chat page title via the UI

### DIFF
--- a/modules/ocha_ai_chat/components/chat-popup/chat-popup.js
+++ b/modules/ocha_ai_chat/components/chat-popup/chat-popup.js
@@ -2,10 +2,12 @@
   'use strict';
 
   function processPopup(popup) {
+    const title = document.querySelector('.ocha-ai-chat-chat-popup__title');
+
     // Mark the popup as processed so the following code runs only once.
     popup.setAttribute('data-ocha-ai-chat-chat-popup-processed', '');
     popup.setAttribute('aria-modal', true);
-    popup.setAttribute('aria-label', Drupal.t('Ask about this document'));
+    popup.setAttribute('aria-label', title.innerText);
     popup.setAttribute('role', 'dialog');
     popup.setAttribute('hidden', '');
 

--- a/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
+++ b/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
@@ -1,5 +1,7 @@
 defaults:
   form:
+    form_title: 'Ask ReliefWeb'
+    popup_title: 'Ask about this document'
     instructions:
       value: ''
       format: 'plain_text'

--- a/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
+++ b/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
@@ -50,6 +50,12 @@ ocha_ai_chat.settings:
           type: mapping
           label: 'Default form settings.'
           mapping:
+            form_title:
+              type: string
+              label: 'Title of the chat form'
+            popup_title:
+              type: string
+              label: 'Title of the chat popup'
             instructions:
               type: mapping
               label: 'Instructions.'

--- a/modules/ocha_ai_chat/ocha_ai_chat.routing.yml
+++ b/modules/ocha_ai_chat/ocha_ai_chat.routing.yml
@@ -3,6 +3,7 @@ ocha_ai_chat.chat_form:
   defaults:
     _form: '\Drupal\ocha_ai_chat\Form\OchaAiChatChatForm'
     _title: 'Chat with documents'
+    _title_callback: '\Drupal\ocha_ai_chat\Form\OchaAiChatChatForm::getPageTitle'
   requirements:
     _permission: access ocha ai chat
 ocha_ai_chat.chat_form.popup:

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -94,9 +94,12 @@ class OchaAiChatChatForm extends FormBase {
    *   The page title.
    */
   public function getPageTitle(?bool $popup = NULL): TranslatableMarkup {
-    $limit = $this->getRequest()?->query?->get('limit');
-    if (isset($limit) && $limit == 1) {
-      return $this->t('Ask about this document');
+    $settings = $this->ochaAiChat->getSettings();
+    if (!empty($popup) && !empty($settings['form']['popup_title'])) {
+      return $this->t('@title', ['@title' => $settings['form']['popup_title']]);
+    }
+    elseif (!empty($settings['form']['form_title'])) {
+      return $this->t('@title', ['@title' => $settings['form']['form_title']]);
     }
     return $this->t('Ask about this document');
   }

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
@@ -141,6 +141,16 @@ class OchaAiChatConfigForm extends FormBase {
       '#title' => $this->t('Form settings'),
       '#open' => TRUE,
     ];
+    $form['defaults']['form']['form_title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Form title'),
+      '#default_value' => $defaults['form']['form_title'] ?? NULL,
+    ];
+    $form['defaults']['form']['popup_title'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Popup title'),
+      '#default_value' => $defaults['form']['popup_title'] ?? NULL,
+    ];
     $form['defaults']['form']['instructions'] = [
       '#type' => 'text_format',
       '#title' => $this->t('Instructions'),

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
@@ -145,11 +145,13 @@ class OchaAiChatConfigForm extends FormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Form title'),
       '#default_value' => $defaults['form']['form_title'] ?? NULL,
+      '#description' => $this->t('Title when the form is displayed as a standalone page.'),
     ];
     $form['defaults']['form']['popup_title'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Popup title'),
       '#default_value' => $defaults['form']['popup_title'] ?? NULL,
+      '#description' => $this->t('Title when the form is displayed as a popup.'),
     ];
     $form['defaults']['form']['instructions'] = [
       '#type' => 'text_format',


### PR DESCRIPTION
Refs: RW-1020

This adds 2 new settings on the chat form config page to set the chat page title and chat popup title.

## Tests.

1. Ensure you are using this branch
2. Clear the cache
3. Go to `/admin/config/ocha-ai/chat/config`
4. Check the form title and popup title fields are present.
5. Put some values and save
6. Open the AI chat popup and confirm it's using the new title.