### PR TITLE
chore: style instructions as speech bubbles

### DIFF
--- a/modules/ocha_ai_chat/components/chat-form/chat-form.css
+++ b/modules/ocha_ai_chat/components/chat-form/chat-form.css
@@ -176,6 +176,7 @@ button doesn't overlay any text */
  *
  * Each Q/A results in a chat-like set of bubbles. Think of SMS or WhatsApp.
  */
+.ocha-ai-chat-chat-form__instructions,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat {
   display: flex;
   flex-flow: column nowrap;
@@ -183,10 +184,12 @@ button doesn't overlay any text */
   margin-block-end: 0;
 }
 
+.ocha-ai-chat-chat-form__instructions,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result dd {
   margin: 0;
 }
 
+.ocha-ai-chat-chat-form__instructions,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__q,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__a,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__refs {
@@ -196,6 +199,7 @@ button doesn't overlay any text */
   border-radius: 5px;
 }
 
+.ocha-ai-chat-chat-form__instructions,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__q,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__a {
   text-wrap: balance;
@@ -227,6 +231,7 @@ button doesn't overlay any text */
   margin-block-end: 2rem;
 }
 
+.ocha-ai-chat-chat-form__instructions,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__a,
 .ocha-ai-chat-chat-form .ocha-ai-chat-result .chat__refs {
   align-self: flex-start;

--- a/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
+++ b/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
@@ -1,8 +1,6 @@
 defaults:
   form:
-    instructions:
-      value: ''
-      format: 'plain_text'
+    instructions: "Hi! I'm the ReliefWeb chat bot.\nI can provide information about the document you're viewing.\nFeel free to ask any questions!"
     feedback: ''
     formatting: 'basic'
   plugins:

--- a/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
+++ b/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
@@ -51,15 +51,8 @@ ocha_ai_chat.settings:
           label: 'Default form settings.'
           mapping:
             instructions:
-              type: mapping
+              type: string
               label: 'Instructions.'
-              mapping:
-                value:
-                  type: string
-                  label: 'Text.'
-                format:
-                  type: string
-                  label: 'Text format.'
             feedback:
               type: string
               label: 'Feedback mode.'

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -159,14 +159,18 @@ class OchaAiChatChatForm extends FormBase {
     ];
 
     // Output instructions as part of scrollable chat history.
-    if (!empty($defaults['form']['instructions']['value'])) {
-      $form['chat']['content'] = [
-        '#type' => 'processed_text',
-        '#prefix' => '<div id="ocha-ai-chat-instructions" class="ocha-ai-chat-chat-form__instructions">',
-        '#suffix' => '</div>',
-        '#text' => $defaults['form']['instructions']['value'],
-        '#format' => $defaults['form']['instructions']['format'] ?? 'text_editor_simple',
-      ];
+    if (!empty($defaults['form']['instructions'])) {
+      // Split text into paragraphs.
+      $instructions = preg_split("/\R/", $defaults['form']['instructions']);
+      foreach ($instructions as $index => $instruction) {
+        $form['chat']['instruction_' . $index] = [
+          '#type' => 'inline_template',
+          '#template' => '<dl class="ocha-ai-chat-chat-form__instructions"><dd><dt class="visually-hidden">Instruction</dt>{{ instruction|raw }}</dd></dl>',
+          '#context' => [
+            'instruction' => $instruction,
+          ],
+        ];
+      }
     }
 
     // Get the feedback type to use for each history entry.

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatConfigForm.php
@@ -142,10 +142,10 @@ class OchaAiChatConfigForm extends FormBase {
       '#open' => TRUE,
     ];
     $form['defaults']['form']['instructions'] = [
-      '#type' => 'text_format',
+      '#type' => 'textarea',
       '#title' => $this->t('Instructions'),
-      '#format' => $defaults['form']['instructions']['format'] ?? 'text_editor_simple',
-      '#default_value' => $defaults['form']['instructions']['value'] ?? NULL,
+      '#default_value' => $defaults['form']['instructions'] ?? NULL,
+      '#description' => $this->t("Welcome message shown when chat popup opens. New lines will be shown as separate message 'bubbles'."),
     ];
     $form['defaults']['form']['feedback'] = [
       '#type' => 'select',


### PR DESCRIPTION
Refs: RW-1012

This uses the styling of the bubbles, so removes the option to format instruction text, which also makes it easier to detect new lines.