### PR TITLE
[RW-1024] Prevent XSS

### DIFF
--- a/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatChatForm.php
@@ -174,7 +174,6 @@ class OchaAiChatChatForm extends FormBase {
 
     // Get the feedback type to use for each history entry.
     $feedback_type = $defaults['form']['feedback'] ?? 'detailed';
-    $formatting = $defaults['form']['formatting'] ?? 'none';
 
     foreach (json_decode($history, TRUE) ?? [] as $index => $record) {
       // Used on two different form elements; they must match to function.
@@ -188,10 +187,10 @@ class OchaAiChatChatForm extends FormBase {
       ];
       $form['chat'][$index]['result'] = [
         '#type' => 'inline_template',
-        '#template' => '<dl class="chat"><div class="chat__q"><dt class="visually-hidden">Question</dt><dd>{{ question }}</dd></div><div class="chat__a"><dt class="visually-hidden">Answer</dt><dd id="{{ answer_id }}">{{ answer|raw }}</dd></div>{% if references %}<div class="chat__refs"><dt>References</dt><dd>{{ references }}</dd></div>{% endif %}</dl>',
+        '#template' => '<dl class="chat"><div class="chat__q"><dt class="visually-hidden">Question</dt><dd>{{ question }}</dd></div><div class="chat__a"><dt class="visually-hidden">Answer</dt><dd id="{{ answer_id }}">{{ answer|trim|nl2br }}</dd></div>{% if references %}<div class="chat__refs"><dt>References</dt><dd>{{ references }}</dd></div>{% endif %}</dl>',
         '#context' => [
           'question' => $record['question'],
-          'answer' => $formatting !== 'none' ? $this->formatAnswer($record['answer'], $formatting) : $record['answer'],
+          'answer' => $record['answer'],
           'answer_id' => $answer_id,
           'references' => $this->formatReferences($record['references']),
         ],


### PR DESCRIPTION
Refs: RW-1024

This makes sure the answers are sanitized while preserving the basic formatting (line breaks).

There is a bit of leftovers (`formatAnswer` and the formatting settings) but we may want to re-use them if we ever expand on the formatting.
