### PR TITLE
[RW-1044] Context expansion

### DIFF
--- a/config/schema/ocha_ai.schema.yml
+++ b/config/schema/ocha_ai.schema.yml
@@ -264,7 +264,7 @@ ocha_ai.plugin.text_extractor.mupdf:
 # Elasticsearch source plugin settings.
 ocha_ai.plugin.vector_store.elasticsearch:
   type: ocha_ai.plugin.vector_store
-  label: 'Elasticsearch source plugin settings.'
+  label: 'Elasticsearch vector store plugin settings.'
   mapping:
     url:
       type: string
@@ -294,10 +294,30 @@ ocha_ai.plugin.vector_store.elasticsearch:
       type: float
       label: 'Coefficient for the standard deviation to determine the similarity cut-off for relevancy'
 
+ocha_ai.plugin.vector_store.elasticsearch_flattened:
+  type: ocha_ai.plugin.vector_store.elasticsearch
+  label: 'Elasticsearch flattened vector store plugin settings.'
+  mapping:
+    expand_passage_before:
+      type: integer
+      label: 'Number of adjacent text passages to prepend to the text when passed as context.'
+    expand_passage_after:
+      type: integer
+      label: 'Number of adjacent text passages to append to the text when passed as context.'
+
+
+ocha_ai.plugin.text_splitter.nlp_sentence:
+  type: ocha_ai.plugin.text_splitter
+  label: 'NLP sentence text splitter settings.'
+  mapping:
+    endpoint:
+      type: string
+      label: 'NLP text splitting API endpoint.'
+
 ocha_ai.plugin.text_splitter.sentence:
   type: ocha_ai.plugin.text_splitter
-  label: 'Split a text in groups of sentences'
+  label: 'Sentence text splitter settings.'
 
 ocha_ai.plugin.text_splitter.token:
   type: ocha_ai.plugin.text_splitter
-  label: 'Split a text into passges based on their estimated token count'
+  label: 'Token text splitter settings.'

--- a/modules/ocha_ai_chat/src/Form/OchaAiChatLogsForm.php
+++ b/modules/ocha_ai_chat/src/Form/OchaAiChatLogsForm.php
@@ -391,7 +391,7 @@ class OchaAiChatLogsForm extends FormBase {
         '#type' => 'inline_template',
         '#template' => '{{ text }}<br><small>Source: {{ sources }}, {{ title }}, {{ date }}</small>',
         '#context' => [
-          'text' => $passage['text'],
+          'text' => $passage['expanded_text'] ?? $passage['text'],
           'sources' => $sources,
           'title' => Link::fromTextAndUrl($source_title, $source_url),
           'date' => $date,

--- a/src/Plugin/CompletionPluginBase.php
+++ b/src/Plugin/CompletionPluginBase.php
@@ -143,7 +143,7 @@ abstract class CompletionPluginBase extends PluginBase implements CompletionPlug
     $context = [];
 
     foreach ($passages as $passage) {
-      $context[] = trim($passage['text']);
+      $context[] = trim($passage['expanded_text'] ?? $passage['text']);
       if (isset($passage['reference'])) {
         $context[] = 'Source: ' . $passage['reference'];
       }

--- a/src/Plugin/ocha_ai/Completion/AwsBedrockTitanTextPremierV1.php
+++ b/src/Plugin/ocha_ai/Completion/AwsBedrockTitanTextPremierV1.php
@@ -67,6 +67,7 @@ class AwsBedrockTitanTextPremierV1 extends AwsBedrock {
         <instruction>
         Your answer should ONLY be drawn from the provided search results above, never include answers outside of the search results provided.
         When you reply, first find exact quotes in the context relevant to the user\'s question and write them down word for word inside <thinking></thinking> XML tags. This is a space for you to write down relevant content and will not be shown to the user. Once you are done extracting relevant quotes, answer the question.  Put your answer to the user inside <answer></answer> XML tags.
+        Form a full sentence when answering.
         <instruction>
 
         <instruction>

--- a/src/Plugin/ocha_ai/TextSplitter/NLPSentence.php
+++ b/src/Plugin/ocha_ai/TextSplitter/NLPSentence.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ocha_ai\Plugin\ocha_ai\TextSplitter;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ocha_ai\Attribute\OchaAiTextSplitter;
+use Drupal\ocha_ai\Plugin\TextSplitterPluginBase;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Split a text in groups of sentences.
+ */
+#[OchaAiTextSplitter(
+  id: 'nlp_sentence',
+  label: new TranslatableMarkup('NLP sentence'),
+  description: new TranslatableMarkup('Split a text into sentences using a NLP service.')
+)]
+class NLPSentence extends TextSplitterPluginBase {
+
+  /**
+   * The HTTP client service.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected ClientInterface $httpClient;
+
+  /**
+   * Constructs a \Drupal\Component\Plugin\PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory service.
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The HTTP client service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ConfigFactoryInterface $config_factory,
+    LoggerChannelFactoryInterface $logger_factory,
+    ClientInterface $http_client,
+  ) {
+    parent::__construct(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $config_factory,
+      $logger_factory
+    );
+
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('logger.factory'),
+      $container->get('http_client')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function splitText(string $text, ?int $length = NULL, ?int $overlap = NULL, string $language = 'en'): array {
+    $endpoint = $this->getPluginSetting('endpoint');
+
+    try {
+      $response = $client = $this->httpClient->post($endpoint, [
+        'json' => [
+          'language' => $language,
+          'text' => $text,
+        ],
+      ]);
+
+      $data = $response->getBody()->getContents();
+      $data = json_decode($data, TRUE, flags: \JSON_THROW_ON_ERROR);
+
+      return $data['sentences'] ?? [];
+    }
+    catch (\Exception $exception) {
+      $this->getLogger()->error(strtr('Error while splitting text into sentences: @error', [
+        '@error' => $exception->getMessage(),
+      ]));
+
+    }
+
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $plugin_type = $this->getPluginType();
+    $plugin_id = $this->getPluginId();
+    $config = $this->getConfiguration() + $this->defaultConfiguration();
+
+    $form['plugins'][$plugin_type][$plugin_id]['endpoint'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Endpoint'),
+      '#description' => $this->t('Endpoint of the API.'),
+      '#default_value' => $config['endpoint'] ?? NULL,
+      '#required' => TRUE,
+    ];
+
+    $form['plugins'][$plugin_type][$plugin_id]['length']['#access'] = FALSE;
+    $form['plugins'][$plugin_type][$plugin_id]['overlap']['#access'] = FALSE;
+
+    return $form;
+  }
+
+}

--- a/src/Plugin/ocha_ai/VectorStore/ElasticsearchFlattened.php
+++ b/src/Plugin/ocha_ai/VectorStore/ElasticsearchFlattened.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\ocha_ai\Plugin\ocha_ai\VectorStore;
 
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\ocha_ai\Attribute\OchaAiVectorStore;
 
@@ -16,6 +17,35 @@ use Drupal\ocha_ai\Attribute\OchaAiVectorStore;
   description: new TranslatableMarkup('Use Elasticsearch Flattened as vector store.')
 )]
 class ElasticsearchFlattened extends Elasticsearch {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $plugin_type = $this->getPluginType();
+    $plugin_id = $this->getPluginId();
+    $config = $this->getConfiguration() + $this->defaultConfiguration();
+
+    $form['plugins'][$plugin_type][$plugin_id]['expand_passage_before'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Expand passage - Before'),
+      '#description' => $this->t('Number of adjacent text passages to prepend to the text when passed as context.'),
+      '#default_value' => $config['expand_passage_before'] ?? 0,
+      '#required' => FALSE,
+    ];
+
+    $form['plugins'][$plugin_type][$plugin_id]['expand_passage_after'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Expand passage - After'),
+      '#description' => $this->t('Number of adjacent text passages to append to the text when passed as context.'),
+      '#default_value' => $config['expand_passage_after'] ?? 0,
+      '#required' => FALSE,
+    ];
+
+    return $form;
+  }
 
   /**
    * {@inheritdoc}
@@ -206,10 +236,6 @@ class ElasticsearchFlattened extends Elasticsearch {
       return [];
     }
 
-    if (!$this->indexExists($index)) {
-      return [];
-    }
-
     $query = [
       '_source' => [
         'id',
@@ -266,62 +292,210 @@ class ElasticsearchFlattened extends Elasticsearch {
     $response = $this->request('POST', $index . '/_search', $query);
 
     $data = $this->getResponseContent($response, 'POST', $index . '/_search');
-    if (!is_null($data)) {
-
-      // Get the list of passages and their similarity score.
-      $passages = [];
-      foreach ($data['hits']['hits'] ?? [] as $hit) {
-        $document = $hit['_source'];
-        unset($document['contents']);
-
-        $contents = [];
-        foreach ($hit['_source']['contents'] as $content) {
-          $contents[$content['id']] = $content;
-        }
-
-        foreach ($hit['inner_hits']['passages']['hits']['hits'] ?? [] as $inner_hit) {
-          $passage = $inner_hit['_source'] + [
-            'score' => $inner_hit['_score'],
-            'source' => $document,
-          ];
-
-          $content = $contents[$inner_hit['_source']['content']];
-          if ($content['type'] === 'file') {
-            $passage['source']['attachment'] = [
-              'url' => $content['url'],
-              'page' => $inner_hit['_source']['page'],
-            ];
-          }
-
-          $passages[] = $passage;
-        }
-      }
-
-      if (empty($passages)) {
-        return [];
-      }
-
-      // Sort by passage score to have the most relevant first.
-      usort($passages, function ($a, $b) {
-        return $b['score'] <=> $a['score'];
-      });
-
-      // Retrieve the minimum similarity to be considered relevant.
-      $similaries = array_map(function ($passage) {
-        return $passage['score'] ?? 1.0;
-      }, $passages);
-      $cutoff = $this->getSimilarityScoreCutOff($similaries);
-
-      // Exclude irrelevant contents.
-      $passages = array_filter($passages, function ($passage) use ($cutoff) {
-        return $passage['score'] >= $cutoff;
-      });
-
-      // Limit the number of passages.
-      return array_slice($passages, 0, $limit);
+    if (is_null($data)) {
+      return [];
     }
 
-    return [];
+    // Get the list of passages and their similarity score.
+    $passages = [];
+    foreach ($data['hits']['hits'] ?? [] as $hit) {
+      $document = $hit['_source'];
+      unset($document['contents']);
+
+      $contents = [];
+      foreach ($hit['_source']['contents'] as $content) {
+        $contents[$content['id']] = $content;
+      }
+
+      foreach ($hit['inner_hits']['passages']['hits']['hits'] ?? [] as $inner_hit) {
+        $passage = $inner_hit['_source'] + [
+          'score' => $inner_hit['_score'],
+          'source' => $document,
+        ];
+
+        $content = $contents[$inner_hit['_source']['content']];
+        if ($content['type'] === 'file') {
+          $passage['source']['attachment'] = [
+            'url' => $content['url'],
+            'page' => $inner_hit['_source']['page'],
+          ];
+        }
+
+        $passages[] = $passage;
+      }
+    }
+
+    if (empty($passages)) {
+      return [];
+    }
+
+    // Sort by passage score to have the most relevant first.
+    usort($passages, function ($a, $b) {
+      return $b['score'] <=> $a['score'];
+    });
+
+    // Retrieve the minimum similarity to be considered relevant.
+    $similaries = array_map(function ($passage) {
+      return $passage['score'] ?? 1.0;
+    }, $passages);
+    $cutoff = $this->getSimilarityScoreCutOff($similaries);
+
+    // Exclude irrelevant contents.
+    $passages = array_filter($passages, function ($passage) use ($cutoff) {
+      return $passage['score'] >= $cutoff;
+    });
+
+    // Expand the text of the passages with the text of the adjacent passages
+    // to enrich the context.
+    $passages = $this->expandPassages($index, $passages);
+
+    // Limit the number of passages.
+    return array_slice($passages, 0, $limit);
+  }
+
+  /**
+   * Expand the text of the passages with the text of the adjacent passages.
+   *
+   * @param string $elasticsearch_index
+   *   Elasticsearch index to query.
+   * @param array $passages
+   *   Relevant passages.
+   *
+   * @return array
+   *   The passages with an expanded_text property with the concatenated
+   *   text of the adjacent passages.
+   */
+  protected function expandPassages(string $elasticsearch_index, array $passages): array {
+    // @todo add plugin settings for those.
+    $before = $this->getPluginSetting('expand_passage_before', 0, FALSE);
+    $after = $this->getPluginSetting('expand_passage_after', 0, FALSE);
+
+    if (empty($before) && empty($after)) {
+      return $passages;
+    }
+
+    $indices = array_map(function ($passage) {
+      return $passage['index'];
+    }, $passages);
+
+    $adjacent_passages = $this->getAdjacentPassages($elasticsearch_index, $indices, $before, $after);
+
+    foreach ($passages as $key => $passage) {
+      $index = $passage['index'];
+
+      $adjacent_indices = [];
+      if ($before > 0) {
+        for ($i = $index - 1; $i >= max($index - $before, 0); $i--) {
+          $adjacent_indices[] = $i;
+        }
+      }
+      if ($after > 0) {
+        for ($i = $index + 1; $i <= $index + $after; $i++) {
+          $adjacent_indices[] = $i;
+        }
+      }
+
+      $expanded_text_parts = [$index => trim($passage['text'])];
+
+      foreach ($adjacent_indices as $adjacent_index) {
+        if (!isset($adjacent_passages[$adjacent_index])) {
+          continue;
+        }
+        $adjacent_passage = $adjacent_passages[$adjacent_index];
+
+        if ($passage['content'] !== $adjacent_passage['content']) {
+          continue;
+        }
+
+        // @todo maybe calculate the similarity to the question embedding and
+        // discard adjacent passages that are way too dissimilar.
+        //
+        // @todo if we can get more information about a passage like, the
+        // paragraph/table/list index, then we could discard passages not in
+        // the same "block".
+        $expanded_text_parts[$adjacent_index] = trim($adjacent_passage['text']);
+      }
+
+      ksort($expanded_text_parts);
+
+      // @todo the separator may need to be adjusted based on the language.
+      $passages[$key]['expanded_text'] = implode(' ', $expanded_text_parts);
+    }
+
+    return $passages;
+  }
+
+  /**
+   * Retrieve the adjacent passages.
+   *
+   * @param string $elasticsearch_index
+   *   Elasticsearch index to query.
+   * @param array<int> $indices
+   *   Already retrieved passage indices.
+   * @param int $before
+   *   How many previous passages to retrieve.
+   * @param int $after
+   *   How many next passages to retrieves.
+   *
+   * @return array
+   *   Passages with their text and embeddings keyed by their index.
+   */
+  protected function getAdjacentPassages(string $elasticsearch_index, array $indices, int $before, int $after): array {
+    $adjacent_indices = [];
+    foreach ($indices as $index) {
+      if ($before > 0) {
+        for ($i = $index - 1; $i >= max($index - $before, 0); $i--) {
+          $adjacent_indices[] = $i;
+        }
+      }
+      if ($after > 0) {
+        for ($i = $index + 1; $i <= $index + $after; $i++) {
+          $adjacent_indices[] = $i;
+        }
+      }
+    }
+
+    $query = [
+      '_source' => FALSE,
+      'size' => count($adjacent_indices),
+      'query' => [
+        'nested' => [
+          'path' => 'passages',
+          'query' => [
+            'terms' => [
+              'passages.index' => $adjacent_indices,
+            ],
+          ],
+          'inner_hits' => [
+            '_source' => [
+              'passages.index',
+              'passages.content',
+              'passages.page',
+              'passages.text',
+              'passages.embedding',
+            ],
+            'size' => count($adjacent_indices),
+          ],
+        ],
+      ],
+    ];
+
+    $response = $this->request('POST', $elasticsearch_index . '/_search', $query);
+
+    $data = $this->getResponseContent($response, 'POST', $elasticsearch_index . '/_search');
+    if (is_null($data)) {
+      return [];
+    }
+
+    // Get the list of passages and their similarity score.
+    $passages = [];
+    foreach ($data['hits']['hits'] ?? [] as $hit) {
+      foreach ($hit['inner_hits']['passages']['hits']['hits'] ?? [] as $inner_hit) {
+        $passages[$inner_hit['_source']['index']] = $inner_hit['_source'];
+      }
+    }
+
+    return $passages;
   }
 
 }


### PR DESCRIPTION
Refs: RW-1044

Add settings to enrich the context  of relevant passages by retrieving adjacent passages.

By default, this is disabled (passages before and after are set to 0) so there is no change to the current behavior.

This also adds a new sentence splitter using the OCHA AI helper: https://github.com/UN-OCHA/ocha_ai_helper. This plugin is completely optional and was used to test context expansion.