### PR TITLE
[RW-1051] Add ranker plugin type to rerank passages

### DIFF
--- a/config/install/ocha_ai.settings.yml
+++ b/config/install/ocha_ai.settings.yml
@@ -12,6 +12,10 @@ plugins:
         Based solely on the information below, please answer the user's question. Please do not make things up and say you don't know if you cannot answer.
 
         {{ context }}
+  ranker:
+    ocha_ai_helper_ranker:
+      endpoint: http://ocha-ai-helper/text/correlate/texts
+      limit: 5
   source:
     reliefweb:
       api_url: https://api.reliefweb.int/v1
@@ -42,6 +46,8 @@ defaults:
       plugin_id: aws_bedrock
     embedding:
       plugin_id: aws_bedrock
+    ranker:
+      plugin_id: ocha_ai_helper_ranker
     source:
       plugin_id: reliefweb
     text_extractor:

--- a/config/schema/ocha_ai.schema.yml
+++ b/config/schema/ocha_ai.schema.yml
@@ -162,6 +162,15 @@ ocha_ai.plugin.embedding:
       type: integer
       label: 'Max tokens.'
 
+# Ranker plugin base settings.
+ocha_ai.plugin.ranker:
+  type: mapping
+  label: 'Ranker plugin base settings.'
+  mapping:
+    limit:
+      type: integer
+      label: 'Maximum number of relevant texts to return.'
+
 # Source plugin base settings.
 ocha_ai.plugin.source:
   type: mapping
@@ -227,6 +236,15 @@ ocha_ai.plugin.completion.azure_openai:
 ocha_ai.plugin.embedding.azure_openai:
   type: ocha_ai.plugin.embedding
   label: 'AWS Bedrock embedding plugin settings.'
+
+# OCHA AI Helper ranker plugin settings
+ocha_ai.plugin.ranker.ocha_ai_helper_ranker:
+  type: ocha_ai.plugin.ranker
+  label: 'OCHA AI Helper ranker plugin settings.'
+  mapping:
+    endpoint:
+      type: string
+      label: 'Text ranking API endpoint.'
 
 # ReliefWeb source plugin settings.
 ocha_ai.plugin.source.reliefweb:

--- a/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
+++ b/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
@@ -21,7 +21,7 @@ defaults:
     embedding:
       plugin_id: aws_bedrock
     ranker:
-      plugin_id: ocha_ai_helper_ranker
+      plugin_id: NULL
       limit: 5
     source:
       plugin_id: reliefweb

--- a/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
+++ b/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
@@ -20,6 +20,9 @@ defaults:
       plugin_id: aws_bedrock
     embedding:
       plugin_id: aws_bedrock
+    ranker:
+      plugin_id: ocha_ai_helper_ranker
+      limit: 5
     source:
       plugin_id: reliefweb
     text_extractor:

--- a/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
+++ b/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
@@ -18,6 +18,12 @@ ocha_ai_chat.settings:
           sequence:
             type: ocha_ai.plugin.embedding.[%key]
             label: 'Settings for a embedding plugin.'
+        ranker:
+          type: sequence
+          label: 'List of ranker plugins.'
+          sequence:
+            type: ocha_ai.plugin.ranker.[%key]
+            label: 'Settings for a ranker plugin.'
         source:
           type: sequence
           label: 'List of source plugins.'
@@ -114,6 +120,16 @@ ocha_ai_chat.settings:
                 plugin_id:
                   type: string
                   label: 'Plugin ID.'
+            ranker:
+              type: mapping
+              label: 'Default ranker plugin settings.'
+              mapping:
+                plugin_id:
+                  type: string
+                  label: 'Plugin ID.'
+                limit:
+                  type: integer
+                  label: 'Maximum number of relevant texts to return.'
             source:
               type: mapping
               label: 'Default source plugin settings.'

--- a/modules/ocha_ai_chat/ocha_ai_chat.services.yml
+++ b/modules/ocha_ai_chat/ocha_ai_chat.services.yml
@@ -10,6 +10,7 @@ services:
       - '@datetime.time'
       - '@plugin.manager.ocha_ai.completion'
       - '@plugin.manager.ocha_ai.embedding'
+      - '@plugin.manager.ocha_ai.ranker'
       - '@plugin.manager.ocha_ai.source'
       - '@plugin.manager.ocha_ai.text_extractor'
       - '@plugin.manager.ocha_ai.text_splitter'

--- a/ocha_ai.services.yml
+++ b/ocha_ai.services.yml
@@ -11,6 +11,9 @@ services:
   plugin.manager.ocha_ai.embedding:
     class: Drupal\ocha_ai\Plugin\EmbeddingPluginManager
     parent: default_plugin_manager
+  plugin.manager.ocha_ai.ranker:
+    class: Drupal\ocha_ai\Plugin\RankerPluginManager
+    parent: default_plugin_manager
   plugin.manager.ocha_ai.source:
     class: Drupal\ocha_ai\Plugin\SourcePluginManager
     parent: default_plugin_manager

--- a/src/Attribute/OchaAiRanker.php
+++ b/src/Attribute/OchaAiRanker.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ocha_ai\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a OCHA AI ranker plugin attribute object.
+ *
+ * Plugin Namespace: Plugin\ocha_ai\Ranker.
+ *
+ * @see \Drupal\ocha_ai\Plugin\RankerPluginBase
+ * @see \Drupal\ocha_ai\Plugin\RankerPluginInterface
+ * @see \Drupal\ocha_ai\Plugin\RankerPluginManager
+ * @see plugin_api
+ *
+ * @Attribute
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class OchaAiRanker extends Plugin {
+
+  /**
+   * Constructs a OCHA AI ranker attribute.
+   *
+   * @param string $id
+   *   The plugin ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The label of the plugin.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $description
+   *   The description of the plugin.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly TranslatableMarkup $description,
+  ) {}
+
+}

--- a/src/Form/OchaAiConfigForm.php
+++ b/src/Form/OchaAiConfigForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\ocha_ai\Plugin\CompletionPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\EmbeddingPluginManagerInterface;
+use Drupal\ocha_ai\Plugin\RankerPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\SourcePluginManagerInterface;
 use Drupal\ocha_ai\Plugin\TextExtractorPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\TextSplitterPluginManagerInterface;
@@ -31,6 +32,13 @@ class OchaAiConfigForm extends ConfigFormBase {
    * @var \Drupal\ocha_ai\Plugin\EmbeddingPluginManagerInterface
    */
   protected EmbeddingPluginManagerInterface $embeddingPluginManager;
+
+  /**
+   * Ranker plugin manager.
+   *
+   * @var \Drupal\ocha_ai\Plugin\RankerPluginManagerInterface
+   */
+  protected RankerPluginManagerInterface $rankerPluginManager;
 
   /**
    * Source plugin manager.
@@ -76,6 +84,8 @@ class OchaAiConfigForm extends ConfigFormBase {
    *   The completion plugin manager.
    * @param \Drupal\ocha_ai\Plugin\EmbeddingPluginManagerInterface $embedding_plugin_manager
    *   The embedding plugin manager.
+   * @param \Drupal\ocha_ai\Plugin\RankerPluginManagerInterface $ranker_plugin_manager
+   *   The ranker plugin manager.
    * @param \Drupal\ocha_ai\Plugin\SourcePluginManagerInterface $source_plugin_manager
    *   The source plugin manager.
    * @param \Drupal\ocha_ai\Plugin\TextExtractorPluginManagerInterface $text_extractor_plugin_manager
@@ -89,6 +99,7 @@ class OchaAiConfigForm extends ConfigFormBase {
     ConfigFactoryInterface $config_factory,
     CompletionPluginManagerInterface $completion_plugin_manager,
     EmbeddingPluginManagerInterface $embedding_plugin_manager,
+    RankerPluginManagerInterface $ranker_plugin_manager,
     SourcePluginManagerInterface $source_plugin_manager,
     TextExtractorPluginManagerInterface $text_extractor_plugin_manager,
     TextSplitterPluginManagerInterface $text_splitter_plugin_manager,
@@ -98,6 +109,7 @@ class OchaAiConfigForm extends ConfigFormBase {
 
     $this->completionPluginManager = $completion_plugin_manager;
     $this->embeddingPluginManager = $embedding_plugin_manager;
+    $this->rankerPluginManager = $ranker_plugin_manager;
     $this->sourcePluginManager = $source_plugin_manager;
     $this->textExtractorPluginManager = $text_extractor_plugin_manager;
     $this->textSplitterPluginManager = $text_splitter_plugin_manager;
@@ -112,6 +124,7 @@ class OchaAiConfigForm extends ConfigFormBase {
       $container->get('config.factory'),
       $container->get('plugin.manager.ocha_ai.completion'),
       $container->get('plugin.manager.ocha_ai.embedding'),
+      $container->get('plugin.manager.ocha_ai.ranker'),
       $container->get('plugin.manager.ocha_ai.source'),
       $container->get('plugin.manager.ocha_ai.text_extractor'),
       $container->get('plugin.manager.ocha_ai.text_splitter'),
@@ -131,6 +144,10 @@ class OchaAiConfigForm extends ConfigFormBase {
       'embedding' => [
         'label' => $this->t('Embedding'),
         'manager' => $this->embeddingPluginManager,
+      ],
+      'ranker' => [
+        'label' => $this->t('Ranker'),
+        'manager' => $this->rankerPluginManager,
       ],
       'source' => [
         'label' => $this->t('Document source'),

--- a/src/Plugin/RankerPluginBase.php
+++ b/src/Plugin/RankerPluginBase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Base ranker plugin.
+ */
+abstract class RankerPluginBase extends PluginBase implements RankerPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginType(): string {
+    return 'ranker';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $plugin_type = $this->getPluginType();
+    $plugin_id = $this->getPluginId();
+    $config = $this->getConfiguration() + $this->defaultConfiguration();
+
+    $form['plugins'][$plugin_type][$plugin_id]['limit'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Limit'),
+      '#description' => $this->t('Maximum number of relevant texts to return after the ranking.'),
+      '#default_value' => $config['limit'] ?? NULL,
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+}

--- a/src/Plugin/RankerPluginInterface.php
+++ b/src/Plugin/RankerPluginInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+/**
+ * Interface for the ranker plugins.
+ */
+interface RankerPluginInterface {
+
+  /**
+   * Rank texts.
+   *
+   * @param string $text
+   *   Text to which the other texts will be compared (ex: question).
+   * @param array<string> $texts
+   *   Texts to rank by relevance to the given text.
+   * @param string $language
+   *   Language of the texts.
+   * @param int|null $limit
+   *   Maximum number of relevant texts to return.
+   *
+   * @return array
+   *   Ranked texts.
+   */
+  public function rankTexts(string $text, array $texts, string $language, ?int $limit = NULL): array;
+
+}

--- a/src/Plugin/RankerPluginManager.php
+++ b/src/Plugin/RankerPluginManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Plugin manager for the ranker plugins.
+ */
+class RankerPluginManager extends PluginManagerBase implements RankerPluginManagerInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
+    parent::__construct(
+      'Plugin/ocha_ai/Ranker',
+      $namespaces,
+      $module_handler,
+      'Drupal\ocha_ai\Plugin\RankerPluginInterface',
+      'Drupal\ocha_ai\Attribute\OchaAiRanker'
+    );
+
+    $this->setCacheBackend($cache_backend, 'ocha_ai_ranker_plugins');
+    $this->alterInfo('ocha_ai_ranker_info');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginType(): string {
+    return 'ranker';
+  }
+
+}

--- a/src/Plugin/RankerPluginManagerInterface.php
+++ b/src/Plugin/RankerPluginManagerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+/**
+ * Interface for the ranker plugin manager.
+ */
+interface RankerPluginManagerInterface {
+
+}

--- a/src/Plugin/ocha_ai/Ranker/OchaAiHelperRanker.php
+++ b/src/Plugin/ocha_ai/Ranker/OchaAiHelperRanker.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ocha_ai\Plugin\ocha_ai\Ranker;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ocha_ai\Attribute\OchaAiRanker;
+use Drupal\ocha_ai\Plugin\RankerPluginBase;
+use GuzzleHttp\ClientInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Split a text in groups of sentences.
+ */
+#[OchaAiRanker(
+  id: 'ocha_ai_helper_ranker',
+  label: new TranslatableMarkup('OCHA AI Helper - Ranker'),
+  description: new TranslatableMarkup('Rank texts using the python FlashRank library exposed via the OCHA AI Helper API.')
+)]
+class OchaAiHelperRanker extends RankerPluginBase {
+
+  /**
+   * The HTTP client service.
+   *
+   * @var \GuzzleHttp\ClientInterface
+   */
+  protected ClientInterface $httpClient;
+
+  /**
+   * Constructs a \Drupal\Component\Plugin\PluginBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   *   The logger factory service.
+   * @param \GuzzleHttp\ClientInterface $http_client
+   *   The HTTP client service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ConfigFactoryInterface $config_factory,
+    LoggerChannelFactoryInterface $logger_factory,
+    ClientInterface $http_client,
+  ) {
+    parent::__construct(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $config_factory,
+      $logger_factory
+    );
+
+    $this->httpClient = $http_client;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('logger.factory'),
+      $container->get('http_client')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function rankTexts(string $text, array $texts, string $language, ?int $limit = NULL): array {
+    if (empty($text) || empty($texts)) {
+      return [];
+    }
+
+    $limit = $limit ?? $this->getPluginSetting('limit') ?? count($texts);
+    $endpoint = $this->getPluginSetting('endpoint');
+
+    try {
+      $response = $client = $this->httpClient->post($endpoint, [
+        'json' => [
+          'language' => $language,
+          'text' => $text,
+          'texts' => $texts,
+          'limit' => $limit,
+        ],
+      ]);
+
+      $data = $response->getBody()->getContents();
+      $data = json_decode($data, TRUE, flags: \JSON_THROW_ON_ERROR);
+
+      $texts = $data['texts'] ?? [];
+    }
+    catch (\Exception $exception) {
+      // Simply log the error and return the original list of texts.
+      $this->getLogger()->error(strtr('Error while ranking texts: @error', [
+        '@error' => $exception->getMessage(),
+      ]));
+    }
+
+    return array_slice($texts, 0, $limit);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $plugin_type = $this->getPluginType();
+    $plugin_id = $this->getPluginId();
+    $config = $this->getConfiguration() + $this->defaultConfiguration();
+
+    $form['plugins'][$plugin_type][$plugin_id]['endpoint'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Endpoint'),
+      '#description' => $this->t('Endpoint of the OCHA AI Helper API.'),
+      '#default_value' => $config['endpoint'] ?? NULL,
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+}


### PR DESCRIPTION
Refs: RW-1051

This adds a new "Ranker" plugin type that can be used to rerank results from the vector store.

By default, no ranker is used, so there is no difference with the current behavior.

The provided plugin is meant to be used with a running instance of the OCHA AI helper: https://github.com/UN-OCHA/ocha_ai_helper/pull/1