### PR TITLE
[RW-1053] Add answer validator plugin type

### DIFF
--- a/config/install/ocha_ai.settings.yml
+++ b/config/install/ocha_ai.settings.yml
@@ -1,4 +1,7 @@
 plugins:
+  answer_validator:
+    similarity:
+      min_similarity: 0.2
   completion:
     aws_bedrock:
       prompt_template: |-
@@ -42,6 +45,8 @@ plugins:
       nested_object_limit: 100000
 defaults:
   plugins:
+    answer_validator:
+      plugin_id: similarity
     completion:
       plugin_id: aws_bedrock
     embedding:

--- a/config/schema/ocha_ai.schema.yml
+++ b/config/schema/ocha_ai.schema.yml
@@ -6,6 +6,12 @@ ocha_ai.settings:
       type: mapping
       label: 'List of plugins.'
       mapping:
+        answer_validator:
+          type: sequence
+          label: 'List of answer validator plugins.'
+          sequence:
+            type: ocha_ai.plugin.answer_validator.[%key]
+            label: 'Settings for a answer validator plugin.'
         completion:
           type: sequence
           label: 'List of completion plugins.'
@@ -18,6 +24,12 @@ ocha_ai.settings:
           sequence:
             type: ocha_ai.plugin.embedding.[%key]
             label: 'Settings for a embedding plugin.'
+        ranker:
+          type: sequence
+          label: 'List of ranker plugins.'
+          sequence:
+            type: ocha_ai.plugin.ranker.[%key]
+            label: 'Settings for a ranker plugin.'
         source:
           type: sequence
           label: 'List of source plugins.'
@@ -57,6 +69,13 @@ ocha_ai.settings:
           type: mapping
           label: 'Default plugins.'
           mapping:
+            answer_validator:
+              type: mapping
+              label: 'Default answer validator plugin settings.'
+              mapping:
+                plugin_id:
+                  type: string
+                  label: 'Plugin ID.'
             completion:
               type: mapping
               label: 'Default completion plugin settings.'
@@ -67,6 +86,13 @@ ocha_ai.settings:
             embedding:
               type: mapping
               label: 'Default embedding plugin settings.'
+              mapping:
+                plugin_id:
+                  type: string
+                  label: 'Plugin ID.'
+            ranker:
+              type: mapping
+              label: 'Default ranker plugin settings.'
               mapping:
                 plugin_id:
                   type: string
@@ -104,6 +130,12 @@ ocha_ai.settings:
                   label: 'Plugin ID.'
 
 ### Base plugin settings. ###
+
+# Ranker plugin base settings.
+ocha_ai.plugin.answer_validation:
+  type: mapping
+  label: 'Answer validator plugin base settings.'
+  mapping:
 
 # Completion plugin base settings.
 ocha_ai.plugin.completion:
@@ -202,6 +234,15 @@ ocha_ai.plugin.vector_store:
   mapping:
 
 ### Plugin settings. ###
+
+# Text splitter plugin base settings.
+ocha_ai.plugin.answer_validator.similarity:
+  type: mapping
+  label: 'Similarity answer validator plugin settings.'
+  mapping:
+    min_similarity:
+      type: float
+      label: 'Minimum similarity for the answer to be considered valid.'
 
 # AWS Bedrock completion plugin settings.
 ocha_ai.plugin.completion.aws_bedrock:

--- a/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
+++ b/modules/ocha_ai_chat/config/install/ocha_ai_chat.settings.yml
@@ -7,7 +7,6 @@ defaults:
       format: 'plain_text'
     feedback: ''
     formatting: 'basic'
-    answer_min_similarity: 1.25
     answers:
       no_document: 'Sorry, no source documents were found.'
       no_passage: 'Sorry, I could not find information to answer the question.'
@@ -16,6 +15,8 @@ defaults:
       document_embedding_error: 'Sorry, there was an error trying to retrieve the documents to the answer to your question.'
       question_embedding_error: 'Sorry, there was an error trying to process the qestion.'
   plugins:
+    answer_validator:
+      plugin_id: similarity
     completion:
       plugin_id: aws_bedrock
     embedding:

--- a/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
+++ b/modules/ocha_ai_chat/config/schema/ocha_ai_chat.schema.yml
@@ -6,6 +6,12 @@ ocha_ai_chat.settings:
       type: mapping
       label: 'List of plugins.'
       mapping:
+        answer_validator:
+          type: sequence
+          label: 'List of answer validator plugins.'
+          sequence:
+            type: ocha_ai.plugin.answer_validator.[%key]
+            label: 'Settings for a answer validator plugin.'
         completion:
           type: sequence
           label: 'List of completion plugins.'
@@ -78,9 +84,6 @@ ocha_ai_chat.settings:
             formatting:
               type: string
               label: 'Formatting mode.'
-            answer_min_similarity:
-              type: float
-              label: 'Minimum similarity between the answer and the context passages to be considered valid.'
             answers:
               type: mapping
               mapping:
@@ -106,6 +109,13 @@ ocha_ai_chat.settings:
           type: mapping
           label: 'Default plugins.'
           mapping:
+            answer_validator:
+              type: mapping
+              label: 'Default answer validator plugin settings.'
+              mapping:
+                plugin_id:
+                  type: string
+                  label: 'Plugin ID.'
             completion:
               type: mapping
               label: 'Default completion plugin settings.'

--- a/modules/ocha_ai_chat/ocha_ai_chat.services.yml
+++ b/modules/ocha_ai_chat/ocha_ai_chat.services.yml
@@ -8,6 +8,7 @@ services:
       - '@current_user'
       - '@database'
       - '@datetime.time'
+      - '@plugin.manager.ocha_ai.answer_validator'
       - '@plugin.manager.ocha_ai.completion'
       - '@plugin.manager.ocha_ai.embedding'
       - '@plugin.manager.ocha_ai.ranker'

--- a/ocha_ai.services.yml
+++ b/ocha_ai.services.yml
@@ -5,6 +5,9 @@ services:
       - { name: cache.bin }
     factory: cache_factory:get
     arguments: [ocha_ai_cache]
+  plugin.manager.ocha_ai.answer_validator:
+    class: Drupal\ocha_ai\Plugin\AnswerValidatorPluginManager
+    parent: default_plugin_manager
   plugin.manager.ocha_ai.completion:
     class: Drupal\ocha_ai\Plugin\CompletionPluginManager
     parent: default_plugin_manager

--- a/src/Attribute/OchaAiAnswerValidator.php
+++ b/src/Attribute/OchaAiAnswerValidator.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ocha_ai\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Defines a OCHA AI answer validator plugin attribute object.
+ *
+ * Plugin Namespace: Plugin\ocha_ai\AnswerValidator.
+ *
+ * @see \Drupal\ocha_ai\Plugin\AnswerValidatorPluginBase
+ * @see \Drupal\ocha_ai\Plugin\AnswerValidatorPluginInterface
+ * @see \Drupal\ocha_ai\Plugin\AnswerValidatorPluginManager
+ * @see plugin_api
+ *
+ * @Attribute
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class OchaAiAnswerValidator extends Plugin {
+
+  /**
+   * Constructs a OCHA AI answer validator attribute.
+   *
+   * @param string $id
+   *   The plugin ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The label of the plugin.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $description
+   *   The description of the plugin.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly TranslatableMarkup $description,
+  ) {}
+
+}

--- a/src/Form/OchaAiConfigForm.php
+++ b/src/Form/OchaAiConfigForm.php
@@ -5,6 +5,7 @@ namespace Drupal\ocha_ai\Form;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\ocha_ai\Plugin\AnswerValidatorPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\CompletionPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\EmbeddingPluginManagerInterface;
 use Drupal\ocha_ai\Plugin\RankerPluginManagerInterface;
@@ -18,6 +19,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Config form for the Ocha AI module.
  */
 class OchaAiConfigForm extends ConfigFormBase {
+
+  /**
+   * Answer validator plugin manager.
+   *
+   * @var \Drupal\ocha_ai\Plugin\AnswerValidatorPluginManagerInterface
+   */
+  protected AnswerValidatorPluginManagerInterface $answerValidatorPluginManager;
 
   /**
    * Completion plugin manager.
@@ -80,6 +88,8 @@ class OchaAiConfigForm extends ConfigFormBase {
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory service.
+   * @param \Drupal\ocha_ai\Plugin\AnswerValidatorPluginManagerInterface $answer_validator_plugin_manager
+   *   The answer validator plugin manager.
    * @param \Drupal\ocha_ai\Plugin\CompletionPluginManagerInterface $completion_plugin_manager
    *   The completion plugin manager.
    * @param \Drupal\ocha_ai\Plugin\EmbeddingPluginManagerInterface $embedding_plugin_manager
@@ -97,6 +107,7 @@ class OchaAiConfigForm extends ConfigFormBase {
    */
   public function __construct(
     ConfigFactoryInterface $config_factory,
+    AnswerValidatorPluginManagerInterface $answer_validator_plugin_manager,
     CompletionPluginManagerInterface $completion_plugin_manager,
     EmbeddingPluginManagerInterface $embedding_plugin_manager,
     RankerPluginManagerInterface $ranker_plugin_manager,
@@ -107,6 +118,7 @@ class OchaAiConfigForm extends ConfigFormBase {
   ) {
     parent::__construct($config_factory);
 
+    $this->answerValidatorPluginManager = $answer_validator_plugin_manager;
     $this->completionPluginManager = $completion_plugin_manager;
     $this->embeddingPluginManager = $embedding_plugin_manager;
     $this->rankerPluginManager = $ranker_plugin_manager;
@@ -122,6 +134,7 @@ class OchaAiConfigForm extends ConfigFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('plugin.manager.ocha_ai.answer_validator'),
       $container->get('plugin.manager.ocha_ai.completion'),
       $container->get('plugin.manager.ocha_ai.embedding'),
       $container->get('plugin.manager.ocha_ai.ranker'),
@@ -137,6 +150,10 @@ class OchaAiConfigForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $plugin_managers = [
+      'answer_validator' => [
+        'label' => $this->t('Answer validator'),
+        'manager' => $this->answerValidatorPluginManager,
+      ],
       'completion' => [
         'label' => $this->t('Completion'),
         'manager' => $this->completionPluginManager,

--- a/src/Plugin/AnswerValidatorPluginBase.php
+++ b/src/Plugin/AnswerValidatorPluginBase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Base answer validator plugin.
+ */
+abstract class AnswerValidatorPluginBase extends PluginBase implements AnswerValidatorPluginInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginType(): string {
+    return 'answer_validator';
+  }
+
+}

--- a/src/Plugin/AnswerValidatorPluginBase.php
+++ b/src/Plugin/AnswerValidatorPluginBase.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\ocha_ai\Plugin;
 
-use Drupal\Core\Form\FormStateInterface;
-
 /**
  * Base answer validator plugin.
  */

--- a/src/Plugin/AnswerValidatorPluginInterface.php
+++ b/src/Plugin/AnswerValidatorPluginInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+/**
+ * Interface for the answer validator plugins.
+ */
+interface AnswerValidatorPluginInterface {
+
+  /**
+   * Validate an answer.
+   *
+   * @param string $answer
+   *   Answer.
+   * @param string $question
+   *   Question.
+   * @param string $passages
+   *   Text passages passed used as context to answer the question.
+   * @param \Drupal\ocha_ai\Plugin\PluginInterface[] $plugins
+   *   Additional plugins used in the pipeline to answer the question. For
+   *   example the embedding plugin.
+   *
+   * @return bool
+   *   TRUE if the answer is considered valid.
+   *
+   * @throws \Exception
+   *   An exception if the plugin cannot perform its validation, for example,
+   *   due to a missing plugin it depends on.
+   */
+  public function validate(string $answer, string $question, array $passages, array $plugins = []): bool;
+
+}

--- a/src/Plugin/AnswerValidatorPluginManager.php
+++ b/src/Plugin/AnswerValidatorPluginManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Plugin manager for the answer validator plugins.
+ */
+class AnswerValidatorPluginManager extends PluginManagerBase implements AnswerValidatorPluginManagerInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
+    parent::__construct(
+      'Plugin/ocha_ai/AnswerValidator',
+      $namespaces,
+      $module_handler,
+      'Drupal\ocha_ai\Plugin\AnswerValidatorPluginInterface',
+      'Drupal\ocha_ai\Attribute\OchaAiAnswerValidator'
+    );
+
+    $this->setCacheBackend($cache_backend, 'ocha_ai_answer_validator_plugins');
+    $this->alterInfo('ocha_ai_answer_validator_info');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPluginType(): string {
+    return 'answer_validator';
+  }
+
+}

--- a/src/Plugin/AnswerValidatorPluginManagerInterface.php
+++ b/src/Plugin/AnswerValidatorPluginManagerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\ocha_ai\Plugin;
+
+/**
+ * Interface for the answer validator plugin manager.
+ */
+interface AnswerValidatorPluginManagerInterface {
+
+}

--- a/src/Plugin/ocha_ai/AnswerValidator/SimilarityValidator.php
+++ b/src/Plugin/ocha_ai/AnswerValidator/SimilarityValidator.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ocha_ai\Plugin\ocha_ai\AnswerValidator;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\ocha_ai\Attribute\OchaAiAnswerValidator;
+use Drupal\ocha_ai\Helpers\VectorHelper;
+use Drupal\ocha_ai\Plugin\AnswerValidatorPluginBase;
+use Drupal\ocha_ai\Plugin\EmbeddingPluginInterface;
+
+/**
+ * Validate an answer by comparing its similarity to the context or question.
+ */
+#[OchaAiAnswerValidator(
+  id: 'similarity',
+  label: new TranslatableMarkup('Similarity'),
+  description: new TranslatableMarkup('Validate an answer by comparing its similarity to the context and/or question.')
+)]
+class SimilarityValidator extends AnswerValidatorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate(string $answer, string $question, array $passages, array $plugins = []): bool {
+    if (empty($answer)) {
+      return FALSE;
+    }
+
+    // @todo adjust the min similarity so that it's high enough to prevent
+    // invalid answers but still pass for valid answers that use only small
+    // parts of the context, for which, the similarity can be low.
+    $min_similarity = $limit ?? $this->getPluginSetting('min_similarity') ?? 0.2;
+
+    // Skip directly if the model considered it was a prompt attack.
+    // @todo instead of that here, have the ::answer() method of the model
+    // throw an exception for example so we are not tied to the what the prompt
+    // tells the model to return.
+    if (mb_stripos($answer, 'Prompt Attack Detected') !== FALSE) {
+      return FALSE;
+    }
+
+    // Search for an embedding plugin.
+    $embedding_plugin = NULL;
+    foreach ($plugins as $plugin) {
+      if ($plugin instanceof EmbeddingPluginInterface) {
+        $embedding_plugin = $plugin;
+      }
+    }
+
+    if (is_null($embedding_plugin)) {
+      throw new \Exception('Pluging @id error: missing embedding plugin.');
+    }
+
+    $answer_embedding = $embedding_plugin->generateEmbedding($answer, TRUE);
+    if (empty($answer_embedding)) {
+      return FALSE;
+    }
+
+    $max_similarity = 0.0;
+    foreach ($passages as $passage) {
+      $embedding = $passage['embedding'] ?? $embedding_plugin->generateEmbedding($passage['text']);
+      if (!empty($embedding)) {
+        $similarity = VectorHelper::cosineSimilarity($embedding, $answer_embedding);
+        $max_similarity = max($max_similarity, $similarity);
+      }
+    }
+
+    return $max_similarity > $min_similarity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state): array {
+    $form = parent::buildConfigurationForm($form, $form_state);
+
+    $plugin_type = $this->getPluginType();
+    $plugin_id = $this->getPluginId();
+    $config = $this->getConfiguration() + $this->defaultConfiguration();
+
+    $form['plugins'][$plugin_type][$plugin_id]['min_similarity'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Minimum similarity'),
+      '#description' => $this->t('Minimum similarity for the answer to be considered valid.'),
+      '#default_value' => $config['min_similarity'] ?? 0.2,
+      '#required' => TRUE,
+      '#step' => '.01',
+      '#min' => 0.0,
+      '#max' => 1.0,
+    ];
+
+    return $form;
+  }
+
+}

--- a/src/Plugin/ocha_ai/Ranker/OchaAiHelperRanker.php
+++ b/src/Plugin/ocha_ai/Ranker/OchaAiHelperRanker.php
@@ -14,7 +14,7 @@ use GuzzleHttp\ClientInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Split a text in groups of sentences.
+ * Rank texts against another text.
  */
 #[OchaAiRanker(
   id: 'ocha_ai_helper_ranker',

--- a/src/Plugin/ocha_ai/Source/ReliefWeb.php
+++ b/src/Plugin/ocha_ai/Source/ReliefWeb.php
@@ -1068,7 +1068,6 @@ class ReliefWeb extends SourcePluginBase {
       // the API query for example as "related documents" etc.
       $document = [
         'id' => $id,
-        'title' => $fields['title'],
         'url' => $fields['url'],
         'source' => $fields['source'],
         'date' => $fields['date'],
@@ -1078,6 +1077,9 @@ class ReliefWeb extends SourcePluginBase {
 
       $title = trim($fields['title']);
       $body = trim($fields['body'] ?? '');
+
+      $document['title'] = $title;
+      $document['body'] = $body;
 
       $document['contents'][] = [
         // @todo might not be so great to use the same id as the parent document

--- a/src/Plugin/ocha_ai/VectorStore/Elasticsearch.php
+++ b/src/Plugin/ocha_ai/VectorStore/Elasticsearch.php
@@ -85,6 +85,8 @@ class Elasticsearch extends VectorStorePluginBase {
       '#default_value' => $config['min_similarity'] ?? NULL,
       '#required' => TRUE,
       '#step' => '.01',
+      '#min' => 0.0,
+      '#max' => 1.0,
     ];
 
     $form['plugins'][$plugin_type][$plugin_id]['cutoff_coefficient'] = [


### PR DESCRIPTION
Refs: RW-1053

This adds a new `answer validator` plugin type so that we can more easily test different validation strategies.

This starts with a `similarity` plugin that just replaces the validation code that was in the OchaAiChat service.

There are also a few fixes:
- Settings schema adjustments with some missing entries
- Min/max values for the minimum similarity for the ES vector stores
- Indexing of the `body` of the RW documents

**Note**: There shouldn't be any change to the current chat behavior but the `ocha_ai.settings.yml` and `ocha_ai_chat.settings.yml` in the RW repo will need to be adjusted when upgrading to the next version of the `ocha_ai` module.