### PR TITLE
[RW-1109] Add generic query method to the completion plugin

### DIFF
--- a/modules/ocha_ai_tag/src/Services/OchaAiTagTagger.php
+++ b/modules/ocha_ai_tag/src/Services/OchaAiTagTagger.php
@@ -6,6 +6,7 @@ use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Database\Connection;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountProxyInterface;
@@ -36,6 +37,13 @@ class OchaAiTagTagger extends OchaAiChat {
    * @var \Drupal\Core\Cache\CacheBackendInterface
    */
   protected CacheBackendInterface $cacheBackend;
+
+  /**
+   * The AI tagger config.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected ImmutableConfig $config;
 
   /**
    * Vocabulary mapping.

--- a/src/Plugin/CompletionPluginInterface.php
+++ b/src/Plugin/CompletionPluginInterface.php
@@ -21,6 +21,24 @@ interface CompletionPluginInterface {
   public function answer(string $question, string $context): string;
 
   /**
+   * Perform a completion query.
+   *
+   * @param string $prompt
+   *   Prompt.
+   * @param string $system_prompt
+   *   Optional system prompt.
+   * @param array $parameters
+   *   Optional parameters for the payload: max_tokens, temperature, top_p.
+   * @param bool $raw
+   *   Whether to return the raw output text or let the plugin do some
+   *   processing if any.
+   *
+   * @return string|null
+   *   The model output text or NULL in case of error when querying the model.
+   */
+  public function query(string $prompt, string $system_prompt = '', array $parameters = [], bool $raw = TRUE): ?string;
+
+  /**
    * Get the prompt template.
    *
    * @return string

--- a/src/Plugin/ocha_ai/Completion/AwsBedrockTitanTextPremierV1.php
+++ b/src/Plugin/ocha_ai/Completion/AwsBedrockTitanTextPremierV1.php
@@ -94,8 +94,10 @@ class AwsBedrockTitanTextPremierV1 extends AwsBedrock {
   /**
    * {@inheritdoc}
    */
-  protected function generateRequestBody(string $prompt): array {
-    $max_tokens = (int) $this->getPluginSetting('max_tokens', 512);
+  protected function generateRequestBody(string $prompt, array $parameters = []): array {
+    $max_tokens = (int) ($parameters['max_tokens'] ?? $this->getPluginSetting('max_tokens', 512));
+    $temperature = (float) ($parameters['temperature'] ?? 0.0);
+    $top_p = (float) ($parameters['top_p'] ?? 0.9);
 
     return [
       'inputText' => $prompt,
@@ -103,8 +105,8 @@ class AwsBedrockTitanTextPremierV1 extends AwsBedrock {
         'maxTokenCount' => $max_tokens,
         // @todo adjust based on the prompt?
         'stopSequences' => [],
-        'temperature' => 0.0,
-        'topP' => 0.9,
+        'temperature' => $temperature,
+        'topP' => $top_p,
       ],
     ];
   }
@@ -112,10 +114,14 @@ class AwsBedrockTitanTextPremierV1 extends AwsBedrock {
   /**
    * {@inheritdoc}
    */
-  protected function parseResponseBody(array $data): string {
+  protected function parseResponseBody(array $data, bool $raw = TRUE): string {
     $response = trim($data['results'][0]['outputText'] ?? '');
     if ($response === '') {
       return '';
+    }
+
+    if ($raw) {
+      return $response;
     }
 
     // Extract the answer.


### PR DESCRIPTION
Refs: RW-1109

This adds a generic query method to the completion plugin to be able to use them outside of the chat (ex:  https://github.com/UN-OCHA/ocha_content_classification).

This doesn't change the current functionality and is fully compatible with the chat.