### PR TITLE
[OPS-11475] Remove dependency on drupal core to allow bump to drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": ">=8.2",
         "aws/aws-sdk-php": "^3.283",
-        "drupal/core": "^10",
         "drupal/honeypot": "^2",
         "openai-php/client": "^0.7",
         "pear/text_languagedetect": "^1.0",


### PR DESCRIPTION
Refs: OPS-11475